### PR TITLE
prep release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### ~
+
+### v0.9.1 (2018-08-30)
 * fixes bug "export places; commas in place names break csv output bug" (#240).
 * fixes bug "momentary hang/pause when adding or reconfiguring sunposition widgets (3x1 and 3x2)".
 * adds permission explanations to fastlane app description.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 31
-        versionName "0.9.0"
+        versionCode 32
+        versionName "0.9.1"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""


### PR DESCRIPTION
* fixes bug "export places; commas in place names break csv output bug" (#240).
* fixes bug "momentary hang/pause when adding or reconfiguring sunposition widgets (3x1 and 3x2)".
* adds permission explanations to fastlane app description.
* adds runtime permission explanations (a dialog displayed prior to each permission request).
* adds privacy link to about dialog (links to https://github.com/forrestguice/SuntimesWidget/wiki/Privacy); 
* added privacy statement to readme.
* updates translation to Polish and Esperanto (eo, pl) (#238, #241 by Verdulo).
* updates translation to Norwegian (nb) (#236 by FTno).