### PR TITLE
Prep release 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### ~
 
+### v0.9.5 (2018-11-11)
+* modifies the default colors to improve contrast and readability (#247, #264, #268).
+* fixes bug "language selectors fails for some languages" (#262).
+* fixes empty widgetlist; an oversized label and icon are now displayed when the list is empty.
+* fixes worldmap bug where the sun/moon positions are drawn despite sunlight/moonlight options toggled off.
+* fixes settings activity iconography (unique icons for each header); the previous patch only fixed this for older Android versions where the icon attribute is completely ignored.
+* updates translation to Polish and Esperanto (eo, pl) (#263, #267 by Verdulo).
+
 ### v0.9.4 (2018-10-28)
 * fixes bug "widgets missing" (#258); installLocation set to internalOnly.
 * fixes appearance of main table for locales with header text shorter than event times; sunset column now has minWidth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ### ~
 
-### v0.9.5 (2018-11-11)
+### v0.9.5 (2018-11-12)
 * modifies the default colors to improve contrast and readability (#247, #264, #268).
 * fixes bug "language selectors fails for some languages" (#262).
 * fixes empty widgetlist; an oversized label and icon are now displayed when the list is empty.
 * fixes worldmap bug where the sun/moon positions are drawn despite sunlight/moonlight options toggled off.
 * fixes settings activity iconography (unique icons for each header); the previous patch only fixed this for older Android versions where the icon attribute is completely ignored.
+* updates translation to Basque (eu) (#271 by beriain).
+* updates translation to Norwegian (nb) (#270 by FTno).
 * updates translation to Polish and Esperanto (eo, pl) (#263, #267 by Verdulo).
 
 ### v0.9.4 (2018-10-28)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 35
-        versionName "0.9.4"
+        versionCode 36
+        versionName "0.9.5"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""


### PR DESCRIPTION
* modifies the default colors to improve contrast and readability (#247, #264, #268).
* fixes bug "language selectors fails for some languages" (#262).
* fixes empty widgetlist; an oversized label and icon are now displayed when the list is empty.
* fixes worldmap bug where the sun/moon positions are drawn despite sunlight/moonlight options toggled off.
* fixes settings activity iconography (unique icons for each header); the previous patch only fixed this for older Android versions where the icon attribute is completely ignored.
* updates translation to Basque (eu) (#271 by beriain).
* updates translation to Norwegian (nb) (#270 by FTno).
* updates translation to Polish and Esperanto (eo, pl) (#263, #267 by Verdulo).

![activity-main0-light](https://user-images.githubusercontent.com/10246147/48372429-cda04a00-e67b-11e8-901f-6f6ffb833ea4.png)