### PR TITLE
prep release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.10.1 (2018-12-23)
+* fixes bug "sun/moon circles are difficult to see (too small)" (#286) on lightmap and worldmap widgets.
+* updates translation to Norwegian (nb) (#285 by FTno).
+* updates dependency (Time4A 4.2-2018g).
+
 ### v0.10.0 (2018-12-09)
 * adds support for themes to the app; it is now possible to customize the app's appearance using widget themes (#264, #275).
 * adds "order" option to sun and moon widgets; "display tomorrow's sunrise once sunset time has passed" (#190).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile 'com.github.forrestguice:sunrisesunsetlib-java:SunriseSunsetCalculator-1.2-p0-fixdst'
     compile 'com.github.caarmen.SunriseSunset:lib-sunrise-sunset:1.1.0'
-    compile group: 'net.time4j', name: 'time4j-android', version: '4.1-2018g'
+    compile group: 'net.time4j', name: 'time4j-android', version: '4.2-2018g'
 
     compile 'com.github.QuadFlask:colorpicker:0.0.13'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 37
-        versionName "0.10.0"
+        versionCode 38
+        versionName "0.10.1"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""


### PR DESCRIPTION
* fixes bug "sun/moon circles are difficult to see (too small)" (#286) on lightmap and worldmap widgets.
* updates translation to Norwegian (nb) (#285 by FTno).
* updates dependency (Time4A 4.2-2018g).