### PR TITLE
equation of time

### DIFF
--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesActivity.java
@@ -359,6 +359,7 @@ public class SuntimesActivity extends AppCompatActivity
         {
             timezoneDialog.setNow(dataset.nowThen(dataset.calendar()));
             timezoneDialog.setLongitude(dataset.location().getLongitudeAsDouble());
+            timezoneDialog.setCalculator(dataset.calculator());
             timezoneDialog.setOnAcceptedListener(onConfigTimeZone);
             timezoneDialog.setOnCanceledListener(onCancelTimeZone);
             //Log.d("DEBUG", "TimeZoneDialog listeners restored.");
@@ -1555,6 +1556,7 @@ public class SuntimesActivity extends AppCompatActivity
         TimeZoneDialog timezoneDialog = new TimeZoneDialog();
         timezoneDialog.setNow(dataset.nowThen(dataset.calendar()));
         timezoneDialog.setLongitude(dataset.location().getLongitudeAsDouble());
+        timezoneDialog.setCalculator(dataset.calculator());
         timezoneDialog.setOnAcceptedListener(onConfigTimeZone);
         timezoneDialog.setOnCanceledListener(onCancelTimeZone);
         timezoneDialog.show(getSupportFragmentManager(), DIALOGTAG_TIMEZONE);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/TimeZoneDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/TimeZoneDialog.java
@@ -308,8 +308,7 @@ public class TimeZoneDialog extends DialogFragment
             WidgetSettings.SolarTimeMode item = (WidgetSettings.SolarTimeMode)item0;
             if (item != null && item == WidgetSettings.SolarTimeMode.APPARENT_SOLAR_TIME)
             {
-                int eot = (calculator != null ? (int)(calculator.equationOfTime(now) * 1000)
-                                              : WidgetTimezones.ApparentSolarTime.equationOfTimeOffset(now.getTimeInMillis()));
+                int eot = WidgetTimezones.ApparentSolarTime.equationOfTimeOffset(now.getTimeInMillis(), calculator);
                 updateExtrasLabel(getContext(), R.string.timezoneExtraApparentSolar, eot);
             } else updateExtrasLabel(null);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/TimeZoneDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/TimeZoneDialog.java
@@ -49,6 +49,7 @@ import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import com.forrestguice.suntimeswidget.calculator.core.SuntimesCalculator;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
 import com.forrestguice.suntimeswidget.settings.WidgetSettings;
 import com.forrestguice.suntimeswidget.settings.WidgetTimezones;
@@ -96,6 +97,12 @@ public class TimeZoneDialog extends DialogFragment
     public void setLongitude( double longitude )
     {
         this.longitude = longitude;
+    }
+
+    private SuntimesCalculator calculator = null;
+    public void setCalculator( SuntimesCalculator calculator )
+    {
+        this.calculator = calculator;
     }
 
     @SuppressWarnings({"deprecation","RestrictedApi"})
@@ -301,7 +308,8 @@ public class TimeZoneDialog extends DialogFragment
             WidgetSettings.SolarTimeMode item = (WidgetSettings.SolarTimeMode)item0;
             if (item != null && item == WidgetSettings.SolarTimeMode.APPARENT_SOLAR_TIME)
             {
-                int eot = WidgetTimezones.ApparentSolarTime.equationOfTimeOffset(now.getTimeInMillis());
+                int eot = (calculator != null ? (int)(calculator.equationOfTime(now) * 1000)
+                                              : WidgetTimezones.ApparentSolarTime.equationOfTimeOffset(now.getTimeInMillis()));
                 updateExtrasLabel(getContext(), R.string.timezoneExtraApparentSolar, eot);
             } else updateExtrasLabel(null);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesData.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesData.java
@@ -200,31 +200,7 @@ public class SuntimesData
         // from timezone settings
         timezone = TimeZone.getTimeZone(WidgetSettings.loadTimezonePref(context, appWidgetId));
         timezoneMode = WidgetSettings.loadTimezoneModePref(context, appWidgetId);
-
-        switch (timezoneMode)
-        {
-            case CUSTOM_TIMEZONE:
-                // empty; use preset timezone value
-                break;
-
-            case CURRENT_TIMEZONE:
-                timezone = TimeZone.getDefault();
-                break;
-
-            case SOLAR_TIME:
-                WidgetSettings.SolarTimeMode solarMode = WidgetSettings.loadSolarTimeModePref(context, appWidgetId);
-                switch (solarMode)
-                {
-                    case APPARENT_SOLAR_TIME:
-                        timezone = WidgetTimezones.apparentSolarTime(context, location);
-                        break;
-
-                    default:
-                        timezone = WidgetTimezones.localMeanTime(context, location);
-                        break;
-                }
-                break;
-        }
+        initTimezone(context);
 
         // from date settings
         WidgetSettings.DateMode dateMode = WidgetSettings.loadDateModePref(context, appWidgetId);
@@ -242,6 +218,34 @@ public class SuntimesData
 
         } else {
             setTodayIsToday();
+        }
+    }
+
+    protected void initTimezone(Context context)
+    {
+        switch (timezoneMode)
+        {
+            case CUSTOM_TIMEZONE:
+                // empty; use preset timezone value
+                break;
+
+            case CURRENT_TIMEZONE:
+                timezone = TimeZone.getDefault();
+                break;
+
+            case SOLAR_TIME:
+                WidgetSettings.SolarTimeMode solarMode = WidgetSettings.loadSolarTimeModePref(context, appWidgetID);
+                switch (solarMode)
+                {
+                    case APPARENT_SOLAR_TIME:
+                        timezone = WidgetTimezones.apparentSolarTime(context, location, calculator);
+                        break;
+
+                    default:
+                        timezone = WidgetTimezones.localMeanTime(context, location);
+                        break;
+                }
+                break;
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesEquinoxSolsticeData.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesEquinoxSolsticeData.java
@@ -154,6 +154,7 @@ public class SuntimesEquinoxSolsticeData extends SuntimesData
         //Log.v("SuntimesWidgetData", "timezone: " + timezone);
 
         initCalculator(context);
+        initTimezone(context);
 
         todaysCalendar = Calendar.getInstance(timezone);
         otherCalendar = Calendar.getInstance(timezone);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesMoonData.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesMoonData.java
@@ -222,6 +222,7 @@ public class SuntimesMoonData extends SuntimesData
     public void calculate()
     {
         initCalculator(context);
+        initTimezone(context);
 
         todaysCalendar = Calendar.getInstance(timezone);
         otherCalendar = Calendar.getInstance(timezone);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesRiseSetData.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesRiseSetData.java
@@ -271,6 +271,7 @@ public class SuntimesRiseSetData extends SuntimesData
         //Log.v("SuntimesWidgetData", "compare mode: " + compareMode.name());
 
         initCalculator(context);
+        initTimezone(context);
 
         todaysCalendar = Calendar.getInstance(timezone);
         otherCalendar = Calendar.getInstance(timezone);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesRiseSetData2.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/SuntimesRiseSetData2.java
@@ -199,6 +199,7 @@ public class SuntimesRiseSetData2 extends SuntimesRiseSetData
         //Log.v("SuntimesWidgetData", "compare mode: " + compareMode.name());
 
         initCalculator(context);
+        initTimezone(context);
 
         for (int i=0; i<calendar.length; i++)
         {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/ca/rmen/sunrisesunset/SunriseSunsetSuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/ca/rmen/sunrisesunset/SunriseSunsetSuntimesCalculator.java
@@ -278,7 +278,7 @@ public class SunriseSunsetSuntimesCalculator implements SuntimesCalculator
     @Override
     public double equationOfTime(Calendar dateTime)
     {
-        return Double.NaN;
+        return Double.POSITIVE_INFINITY;
     }
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/ca/rmen/sunrisesunset/SunriseSunsetSuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/ca/rmen/sunrisesunset/SunriseSunsetSuntimesCalculator.java
@@ -275,5 +275,11 @@ public class SunriseSunsetSuntimesCalculator implements SuntimesCalculator
                 R.string.calculator_displayString_caarmensunrisesunset, SunriseSunsetSuntimesCalculator.FEATURES);
     }
 
+    @Override
+    public double equationOfTime(Calendar dateTime)
+    {
+        return Double.NaN;
+    }
+
 }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/core/SuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/core/SuntimesCalculator.java
@@ -312,7 +312,7 @@ public interface SuntimesCalculator
 
     /**
      * @param dateTime a Calendar representing a given date + time
-     * @return the equation of time value in seconds (or NAN if not supported)
+     * @return the equation of time value in seconds (or INFINITY if not supported)
      * @since 1.5.0 FEATURE_POSITION, FEATURE_RISESET
      */
     double equationOfTime( Calendar dateTime );

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/core/SuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/core/SuntimesCalculator.java
@@ -27,7 +27,7 @@ import java.util.TimeZone;
  * An interface used when calculating sunrise and sunset times. Implementations
  * of this interface are intended to be thin wrappers around third party code.
  *
- * @version 1.4.0
+ * @version 1.5.0
  */
 public interface SuntimesCalculator
 {
@@ -304,9 +304,17 @@ public interface SuntimesCalculator
 
     /**
      * @param objHeight height of the obj (meters)
+     * @param dateTime a Calendar representing a given date + time
      * @return length of shadow (meters) or infinity
      * @since 1.4.0 FEATURE_POSITION, FEATURE_RISESET
      */
     double getShadowLength( double objHeight, Calendar dateTime );
+
+    /**
+     * @param dateTime a Calendar representing a given date + time
+     * @return the equation of time value in seconds (or NAN if not supported)
+     * @since 1.5.0 FEATURE_POSITION, FEATURE_RISESET
+     */
+    double equationOfTime( Calendar dateTime );
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/sunrisesunset_java/SunriseSunsetSuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/sunrisesunset_java/SunriseSunsetSuntimesCalculator.java
@@ -261,5 +261,11 @@ public class SunriseSunsetSuntimesCalculator implements SuntimesCalculator
     public double getShadowLength(double objHeight, Calendar dateTime) {
         return -1;
     }
+
+    @Override
+    public double equationOfTime(Calendar dateTime)
+    {
+        return Double.NaN;
+    }
 }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/sunrisesunset_java/SunriseSunsetSuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/sunrisesunset_java/SunriseSunsetSuntimesCalculator.java
@@ -265,7 +265,7 @@ public class SunriseSunsetSuntimesCalculator implements SuntimesCalculator
     @Override
     public double equationOfTime(Calendar dateTime)
     {
-        return Double.NaN;
+        return Double.POSITIVE_INFINITY;
     }
 }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/time4a/Time4ASuntimesCalculator.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/time4a/Time4ASuntimesCalculator.java
@@ -389,5 +389,12 @@ public abstract class Time4ASuntimesCalculator implements SuntimesCalculator
         return position.getShadowLength(objHeight);
     }
 
+    @Override
+    public double equationOfTime(Calendar dateTime)
+    {
+        Moment moment = TemporalType.JAVA_UTIL_DATE.translate(dateTime.getTime());
+        return SolarTime.equationOfTime(moment, solarTime.getCalculator().name());
+    }
+
 }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
@@ -228,11 +228,14 @@ public class WidgetTimezones
                 double eotSeconds = calculator.equationOfTime(calendar);
                 if (eotSeconds != Double.POSITIVE_INFINITY)
                 {
-                    Log.d("ApparentSolar", "using calculator: eot is: " + (eotSeconds / 60d) + " minutes" );
+                    Log.d("ApparentSolar", "equationOfTime: using " + calculator.name() + ": eot is: " + (eotSeconds / 60d) + " minutes" );
                     int eotMillis = (int)(eotSeconds * 1000);
                     return getRawOffset() + eotMillis;
 
-                } else return getRawOffset() + equationOfTimeOffset(date);    // not supported; use fall-back implementation
+                } else {
+                    Log.d("ApparentSolar", "equationOfTime: not supported by " + calculator.name() + " using fallback: " + (equationOfTimeOffset(date) / 1000d / 60d) );
+                    return getRawOffset() + equationOfTimeOffset(date);    // not supported; use fall-back implementation
+                }
             } else return getRawOffset() + equationOfTimeOffset(date);      // no calculator; use fall-back implementation
         }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
@@ -226,7 +226,7 @@ public class WidgetTimezones
                 Calendar calendar = new GregorianCalendar();
                 calendar.setTimeInMillis(date);
                 double eotSeconds = calculator.equationOfTime(calendar);
-                if (eotSeconds != Double.NaN)
+                if (eotSeconds != Double.POSITIVE_INFINITY)
                 {
                     Log.d("ApparentSolar", "using calculator: eot is: " + (eotSeconds / 60d) + " minutes" );
                     int eotMillis = (int)(eotSeconds * 1000);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
@@ -105,6 +105,11 @@ public class WidgetTimezones
         return new ApparentSolarTime(location.getLongitudeAsDouble(), context.getString(R.string.solartime_apparent));
     }
 
+    public static TimeZone apparentSolarTime(Context context, Location location, SuntimesCalculator calculator)
+    {
+        return new ApparentSolarTime(location.getLongitudeAsDouble(), context.getString(R.string.solartime_apparent), calculator);
+    }
+
     /**
      * LocalMeanTime : TimeZone
      */
@@ -223,6 +228,7 @@ public class WidgetTimezones
                 double eotSeconds = calculator.equationOfTime(calendar);
                 if (eotSeconds != Double.NaN)
                 {
+                    Log.d("ApparentSolar", "using calculator: eot is: " + (eotSeconds / 60d) + " minutes" );
                     int eotMillis = (int)(eotSeconds * 1000);
                     return getRawOffset() + eotMillis;
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
@@ -221,6 +221,11 @@ public class WidgetTimezones
         @Override
         public int getOffset( long date )
         {
+            return getRawOffset() + equationOfTimeOffset(date, calculator);
+        }
+
+        public static int equationOfTimeOffset(long date,SuntimesCalculator calculator)
+        {
             if (calculator != null)
             {
                 Calendar calendar = new GregorianCalendar();
@@ -229,16 +234,15 @@ public class WidgetTimezones
                 if (eotSeconds != Double.POSITIVE_INFINITY)
                 {
                     //Log.d("ApparentSolar", "equationOfTime: using " + calculator.name() + ": eot is: " + (eotSeconds / 60d) + " minutes" );
-                    int eotMillis = (int)(eotSeconds * 1000);
-                    return getRawOffset() + eotMillis;
+                    return (int)(eotSeconds * 1000);
 
                 } else {
                     //Log.d("ApparentSolar", "equationOfTime: not supported by " + calculator.name() + " using fallback: " + (equationOfTimeOffset(date) / 1000d / 60d) );
-                    return getRawOffset() + equationOfTimeOffset(date);    // not supported; use fall-back implementation
+                    return equationOfTimeOffset(date);    // not supported; use fall-back implementation
                 }
             } else {
                 //Log.d("ApparentSolar", "equationOfTime: null calculator, using fallback: " + (equationOfTimeOffset(date) / 1000d / 60d) );
-                return getRawOffset() + equationOfTimeOffset(date);      // no calculator; use fall-back implementation
+                return equationOfTimeOffset(date);      // no calculator; use fall-back implementation
             }
         }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/WidgetTimezones.java
@@ -228,15 +228,18 @@ public class WidgetTimezones
                 double eotSeconds = calculator.equationOfTime(calendar);
                 if (eotSeconds != Double.POSITIVE_INFINITY)
                 {
-                    Log.d("ApparentSolar", "equationOfTime: using " + calculator.name() + ": eot is: " + (eotSeconds / 60d) + " minutes" );
+                    //Log.d("ApparentSolar", "equationOfTime: using " + calculator.name() + ": eot is: " + (eotSeconds / 60d) + " minutes" );
                     int eotMillis = (int)(eotSeconds * 1000);
                     return getRawOffset() + eotMillis;
 
                 } else {
-                    Log.d("ApparentSolar", "equationOfTime: not supported by " + calculator.name() + " using fallback: " + (equationOfTimeOffset(date) / 1000d / 60d) );
+                    //Log.d("ApparentSolar", "equationOfTime: not supported by " + calculator.name() + " using fallback: " + (equationOfTimeOffset(date) / 1000d / 60d) );
                     return getRawOffset() + equationOfTimeOffset(date);    // not supported; use fall-back implementation
                 }
-            } else return getRawOffset() + equationOfTimeOffset(date);      // no calculator; use fall-back implementation
+            } else {
+                //Log.d("ApparentSolar", "equationOfTime: null calculator, using fallback: " + (equationOfTimeOffset(date) / 1000d / 60d) );
+                return getRawOffset() + equationOfTimeOffset(date);      // no calculator; use fall-back implementation
+            }
         }
 
         /**


### PR DESCRIPTION
Improves the accuracy of the apparent solar time calculation by using the `equationOfTime` method provided by the calculator (when available; falls back to the default implementation).

related to #154