### PR TITLE
release 0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### ~
 
 ### v0.11.5 (2019-05-31)
-* now supports playing alarm sounds from the file system (mp3, ogg, etc). [Selecting files requires a file manager app with support for ringtone selection.] 
+* adds support for playing alarm sounds from the file system (mp3, ogg, etc). [Selecting files requires a file manager app with support for ringtone selection.] 
 * fixes bug "alarm sound fails to play from external storage" (#326); alarm notifications will fallback to the default ringtone if the selected sound cannot be played.
-* adds permission READ_EXTERNAL_STORAGE; this permission is needed to play sounds located on the SD card (#326). [PERMISSION]
+* new permission: READ_EXTERNAL_STORAGE. This permission is needed to play sounds located on the SD card (#326). [PERMISSION]
 * improves language resolution for Spanish locales (#147).
 * improves the About Dialog (better translation credits).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### ~
 
+### v0.11.5 (2019-05-31)
+* improves language resolution for Spanish locales (#147).
+* improves the About Dialog (better translation credits).
+
 ### v0.11.4 (2019-05-07)
 * fixes bug "NotificationService is always running" (#323, #324).
 * fixes bug "AlarmClockActivity started multiple times" (#325, #324).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### ~
 
 ### v0.11.5 (2019-05-31)
-* adds support for playing alarm sounds from external storage (mp3, ogg, etc). Selecting files requires a file manager app with support for ringtone selection.
+* now supports playing alarm sounds from the file system (mp3, ogg, etc). [Selecting files requires a file manager app with support for ringtone selection.] 
+* fixes bug "alarm sound fails to play from external storage" (#326); alarm notifications will fallback to the default ringtone if the selected sound cannot be played.
 * adds permission READ_EXTERNAL_STORAGE; this permission is needed to play sounds located on the SD card (#326). [PERMISSION]
-* fixes alarm notifications so that they fallback to the default ringtone if the selected alarm sound cannot be played (#326).
 * improves language resolution for Spanish locales (#147).
 * improves the About Dialog (better translation credits).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### ~
 
 ### v0.11.5 (2019-05-31)
+* adds support for playing alarm sounds from external storage (mp3, ogg, etc). Selecting files requires a file manager app with support for ringtone selection.
+* adds permission READ_EXTERNAL_STORAGE; this permission is needed to play sounds located on the SD card (#326). [PERMISSION]
+* fixes alarm notifications so that they fallback to the default ringtone if the selected alarm sound cannot be played (#326).
 * improves language resolution for Spanish locales (#147).
 * improves the About Dialog (better translation credits).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 45
-        versionName "0.11.4"
+        versionCode 46
+        versionName "0.11.5"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/46.txt
+++ b/fastlane/metadata/android/en-US/changelogs/46.txt
@@ -1,0 +1,5 @@
+* adds support for playing alarm sounds from the file system (mp3, ogg, etc).
+* fixes bug "alarm sound fails to play from external storage" (#326).
+* new permission: READ_EXTERNAL_STORAGE. This permission is needed to play sounds located on the SD card (#326).
+* improves language resolution for Spanish locales (#147).
+* improves the About Dialog (better translation credits).


### PR DESCRIPTION
* adds support for playing alarm sounds from the file system (mp3, ogg, etc). [Selecting files requires a file manager app with support for ringtone selection.] 
* fixes bug "alarm sound fails to play from external storage" (#326); alarm notifications will fallback to the default ringtone if the selected sound cannot be played.
* new permission: READ_EXTERNAL_STORAGE. This permission is needed to play sounds located on the SD card (#326). [PERMISSION]
* improves language resolution for Spanish locales (#147).
* improves the About Dialog (better translation credits).