### PR TITLE
bug333

### DIFF
--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesActivity.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2014-2018 Forrest Guice
+    Copyright (C) 2014-2019 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -18,7 +18,6 @@
 
 package com.forrestguice.suntimeswidget;
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
@@ -45,7 +44,6 @@ import android.os.Parcelable;
 import android.preference.PreferenceActivity;
 import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
@@ -838,10 +836,7 @@ public class SuntimesActivity extends AppCompatActivity
     private void initWarnings(Context context, Bundle savedState)
     {
         timezoneWarning = new SuntimesWarning(WARNINGID_TIMEZONE);
-        timezoneWarning.setWarningListener(warningListener);
-
         dateWarning = new SuntimesWarning(WARNINGID_DATE);
-        dateWarning.setWarningListener(warningListener);
 
         warnings = new ArrayList<SuntimesWarning>();
         warnings.add(timezoneWarning);
@@ -1787,8 +1782,8 @@ public class SuntimesActivity extends AppCompatActivity
 
         verboseAccessibility = AppSettings.loadVerboseAccessibilityPref(this);
         showWarnings = AppSettings.loadShowWarningsPref(this);
-        dateWarning.shouldShow = false;
-        timezoneWarning.shouldShow = false;
+        dateWarning.setShouldShow(false);
+        timezoneWarning.setShouldShow(false);
 
         location = WidgetSettings.loadLocationPref(context, AppWidgetManager.INVALID_APPWIDGET_ID);
         String locationTitle = location.getLabel();
@@ -2010,18 +2005,18 @@ public class SuntimesActivity extends AppCompatActivity
                 {
                     thisString = getString(R.string.future_today);
                     otherString = getString(R.string.future_tomorrow);
-                    dateWarning.shouldShow = true;
+                    dateWarning.setShouldShow(true);
 
                 } else if (data_date.before(time)) {
                     thisString = getString(R.string.past_today);
                     otherString = getString(R.string.past_tomorrow);
-                    dateWarning.shouldShow = true;
+                    dateWarning.setShouldShow(true);
                 }
             }
         }
 
         // date fields
-        ImageSpan dateWarningIcon = (showWarnings && dateWarning.shouldShow) ? SuntimesUtils.createWarningSpan(this, txt_date.getTextSize()) : null;
+        ImageSpan dateWarningIcon = (showWarnings && dateWarning.shouldShow()) ? SuntimesUtils.createWarningSpan(this, txt_date.getTextSize()) : null;
         String dateString = getString(R.string.dateField, thisString, dateFormat.format(data_date));
         SpannableStringBuilder dateSpan = SuntimesUtils.createSpan(this, dateString, SuntimesUtils.SPANTAG_WARNING, dateWarningIcon);
         txt_date.setText(dateSpan);
@@ -2034,8 +2029,8 @@ public class SuntimesActivity extends AppCompatActivity
 
         // timezone field
         TimeZone timezone = dataset.timezone();
-        timezoneWarning.shouldShow = WidgetTimezones.isProbablyNotLocal(timezone, dataset.location(), dataset.date());
-        ImageSpan timezoneWarningIcon = (showWarnings && timezoneWarning.shouldShow) ? SuntimesUtils.createWarningSpan(this, txt_timezone.getTextSize()) : null;
+        timezoneWarning.setShouldShow( WidgetTimezones.isProbablyNotLocal(timezone, dataset.location(), dataset.date()) );
+        ImageSpan timezoneWarningIcon = (showWarnings && timezoneWarning.shouldShow()) ? SuntimesUtils.createWarningSpan(this, txt_timezone.getTextSize()) : null;
 
         boolean useDST = showWarnings && (Build.VERSION.SDK_INT < 24 ? timezone.useDaylightTime()
                                                                      : timezone.observesDaylightTime());
@@ -2116,10 +2111,10 @@ public class SuntimesActivity extends AppCompatActivity
 
     private void showWarnings()
     {
-        if (showWarnings && timezoneWarning.shouldShow && !timezoneWarning.wasDismissed)
+        if (showWarnings && timezoneWarning.shouldShow() && !timezoneWarning.wasDismissed())
         {
             timezoneWarning.initWarning(this, txt_timezone, getString(R.string.timezoneWarning), txt_date.getTextSize());
-            timezoneWarning.snackbar.setAction(getString(R.string.configAction_setTimeZone), new View.OnClickListener()
+            timezoneWarning.getSnackbar().setAction(getString(R.string.configAction_setTimeZone), new View.OnClickListener()
             {
                 @Override
                 public void onClick(View view)
@@ -2131,10 +2126,10 @@ public class SuntimesActivity extends AppCompatActivity
             return;
         }
 
-        if (showWarnings && dateWarning.shouldShow && !dateWarning.wasDismissed)
+        if (showWarnings && dateWarning.shouldShow() && !dateWarning.wasDismissed())
         {
             dateWarning.initWarning(this, card_flipper, getString(R.string.dateWarning), txt_date.getTextSize());
-            dateWarning.snackbar.setAction(getString(R.string.configAction_setDate), new View.OnClickListener()
+            dateWarning.getSnackbar().setAction(getString(R.string.configAction_setDate), new View.OnClickListener()
             {
                 @Override
                 public void onClick(View view)
@@ -2904,161 +2899,6 @@ public class SuntimesActivity extends AppCompatActivity
     }
 
     /**
-     * SuntimesWarning; wraps a Snackbar and some flags.
-     */
-    public static class SuntimesWarning
-    {
-        public static final int ANNOUNCE_DELAY_MS = 500;
-        public static final String KEY_WASDISMISSED = "userDismissedWarning";
-
-        public SuntimesWarning(String id)
-        {
-            this.id = id;
-        }
-        protected String id = "";
-
-        protected Snackbar snackbar = null;
-        protected boolean shouldShow = false;
-        protected boolean wasDismissed = false;
-
-        protected String contentDescription = null;
-        protected View parentView = null;
-
-        public void initWarning(@NonNull Context context, View view, String msg, float textSize)
-        {
-            this.parentView = view;
-            ImageSpan warningIcon = SuntimesUtils.createWarningSpan(context, textSize);
-            SpannableStringBuilder message = SuntimesUtils.createSpan(context, msg, SuntimesUtils.SPANTAG_WARNING, warningIcon);
-            this.contentDescription = msg.replaceAll(Pattern.quote(SuntimesUtils.SPANTAG_WARNING), context.getString(R.string.spanTag_warning));
-
-            wasDismissed = false;
-            snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_INDEFINITE);
-            snackbar.addCallback(snackbarListener);
-            setContentDescription(contentDescription);
-            themeWarning(context, snackbar);
-        }
-
-        @SuppressLint("ResourceType")
-        private void themeWarning(@NonNull Context context, @NonNull Snackbar snackbarWarning)
-        {
-            int[] colorAttrs = { R.attr.snackbar_textColor, R.attr.snackbar_accentColor, R.attr.snackbar_backgroundColor };
-            TypedArray a = context.obtainStyledAttributes(colorAttrs);
-            int textColor = ContextCompat.getColor(context, a.getResourceId(0, android.R.color.primary_text_dark));
-            int accentColor = ContextCompat.getColor(context, a.getResourceId(1, R.color.text_accent_dark));
-            int backgroundColor = ContextCompat.getColor(context, a.getResourceId(2, R.color.card_bg_dark));
-            a.recycle();
-
-            View snackbarView = snackbarWarning.getView();
-            snackbarView.setBackgroundColor(backgroundColor);
-            snackbarWarning.setActionTextColor(accentColor);
-
-            TextView snackbarText = (TextView)snackbarView.findViewById(android.support.design.R.id.snackbar_text);
-            if (snackbarText != null) {
-                snackbarText.setTextColor(textColor);
-                snackbarText.setMaxLines(5);
-            }
-        }
-
-        private Snackbar.Callback snackbarListener = new Snackbar.Callback()
-        {
-            @Override
-            public void onDismissed(Snackbar snackbar, int event)
-            {
-                super.onDismissed(snackbar, event);
-                switch (event)
-                {
-                    case DISMISS_EVENT_SWIPE:
-                        wasDismissed = true;
-                        showNextWarning();
-                        break;
-                }
-            }
-        };
-
-        private void showNextWarning()
-        {
-            if (warningListener != null) {
-                warningListener.onShowNextWarning();
-            }
-        }
-
-        public boolean isShown()
-        {
-            return (snackbar != null && snackbar.isShown());
-        }
-
-        public void show()
-        {
-            if (snackbar != null) {
-                snackbar.show();
-            }
-            announceWarning();
-        }
-
-        public void dismiss()
-        {
-            if (isShown()) {
-                snackbar.dismiss();
-            }
-        }
-
-        public void reset()
-        {
-            wasDismissed = false;
-            shouldShow = false;
-        }
-
-        public void setContentDescription( String value )
-        {
-            this.contentDescription = value;
-            TextView snackText = (TextView) snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
-            if (snackText != null)
-            {
-                snackText.setContentDescription(contentDescription);
-            }
-        }
-
-        public void announceWarning()
-        {
-            if (parentView != null && contentDescription != null)
-            {
-                parentView.postDelayed(new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
-                        SuntimesUtils.announceForAccessibility(parentView, contentDescription);
-                    }
-                }, ANNOUNCE_DELAY_MS);
-            }
-        }
-
-        public void save( Bundle outState )
-        {
-            if (outState != null)
-            {
-                outState.putBoolean(KEY_WASDISMISSED + id, wasDismissed);
-            }
-        }
-
-        public void restore( Bundle savedState )
-        {
-            if (savedState != null)
-            {
-                wasDismissed = savedState.getBoolean(KEY_WASDISMISSED + id, false);
-            }
-        }
-
-        public SuntimesWarningListener warningListener = null;
-        public void setWarningListener(SuntimesWarningListener listener) {
-            warningListener = listener;
-        }
-        public static abstract class SuntimesWarningListener {
-            public abstract void onShowNextWarning();
-        }
-    }
-
-    /**
      * Save the state of warning objects to Bundle.
      * @param outState a Bundle to save state to
      */
@@ -3079,6 +2919,7 @@ public class SuntimesActivity extends AppCompatActivity
         for (SuntimesWarning warning : warnings)
         {
             warning.restore(savedState);
+            warning.setWarningListener(warningListener);
         }
     }
     

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1423,6 +1423,11 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
             }
         }
 
+        Preference volumesPrefs = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_VOLUMES);
+        if (volumesPrefs != null) {
+            volumesPrefs.setOnPreferenceClickListener(onVolumesPrefsClicked(context));
+        }
+
         Preference showLauncher = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_SHOWLAUNCHER);
         if (showLauncher != null)
         {
@@ -1471,7 +1476,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
 
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     if (!notificationsOnLockScreen) {
-                        openGlobalNotificationSettings(context);
+                        openSoundSettings(context);
                     } else {
                         openNotificationSettings(context);
                     }
@@ -1506,7 +1511,19 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
         context.startActivity(intent);
     }
 
-    public static void openGlobalNotificationSettings(@NonNull Context context)
+    private static Preference.OnPreferenceClickListener onVolumesPrefsClicked(final Context context)
+    {
+        return new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference)
+            {
+                openSoundSettings(context);
+                return false;
+            }
+        };
+    }
+
+    public static void openSoundSettings(@NonNull Context context)
     {
         Intent intent = new Intent();
         intent.setAction("android.settings.SOUND_SETTINGS");

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1374,7 +1374,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
 
         int[] colorAttrs = { R.attr.tagColor_warning };
         TypedArray typedArray = context.obtainStyledAttributes(colorAttrs);
-        int colorWarning = ContextCompat.getColor(context, typedArray.getResourceId(1, R.color.warningTag_dark));
+        int colorWarning = ContextCompat.getColor(context, typedArray.getResourceId(0, R.color.warningTag_dark));
         typedArray.recycle();
 
         Preference batteryOptimization = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BATTERYOPT);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWarning.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWarning.java
@@ -1,0 +1,202 @@
+/**
+    Copyright (C) 2014-2019 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.support.v4.content.ContextCompat;
+import android.text.SpannableStringBuilder;
+import android.text.style.ImageSpan;
+import android.view.View;
+import android.widget.TextView;
+
+import java.util.regex.Pattern;
+
+/**
+ * SuntimesWarning; wraps a Snackbar and some flags.
+ */
+public class SuntimesWarning
+{
+    public static final int ANNOUNCE_DELAY_MS = 500;
+    public static final String KEY_WASDISMISSED = "userDismissedWarning";
+
+    public SuntimesWarning(String id)
+    {
+        this.id = id;
+    }
+    protected String id = "";
+
+    private Snackbar snackbar = null;
+    public Snackbar getSnackbar() {
+        return snackbar;
+    }
+
+    private boolean shouldShow = false;
+    public boolean shouldShow() {
+        return shouldShow;
+    }
+    public void setShouldShow(boolean value) {
+        shouldShow = value;
+    }
+
+    private boolean wasDismissed = false;
+    public boolean wasDismissed() {
+        return wasDismissed;
+    }
+
+    protected String contentDescription = null;
+    protected View parentView = null;
+
+    public void initWarning(@NonNull Context context, View view, String msg, float textSize)
+    {
+        this.parentView = view;
+        ImageSpan warningIcon = SuntimesUtils.createWarningSpan(context, textSize);
+        SpannableStringBuilder message = SuntimesUtils.createSpan(context, msg, SuntimesUtils.SPANTAG_WARNING, warningIcon);
+        this.contentDescription = msg.replaceAll(Pattern.quote(SuntimesUtils.SPANTAG_WARNING), context.getString(R.string.spanTag_warning));
+
+        wasDismissed = false;
+        snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_INDEFINITE);
+        snackbar.addCallback(snackbarListener);
+        setContentDescription(contentDescription);
+        themeWarning(context, snackbar);
+    }
+
+    @SuppressLint("ResourceType")
+    private void themeWarning(@NonNull Context context, @NonNull Snackbar snackbarWarning)
+    {
+        int[] colorAttrs = { R.attr.snackbar_textColor, R.attr.snackbar_accentColor, R.attr.snackbar_backgroundColor };
+        TypedArray a = context.obtainStyledAttributes(colorAttrs);
+        int textColor = ContextCompat.getColor(context, a.getResourceId(0, android.R.color.primary_text_dark));
+        int accentColor = ContextCompat.getColor(context, a.getResourceId(1, R.color.text_accent_dark));
+        int backgroundColor = ContextCompat.getColor(context, a.getResourceId(2, R.color.card_bg_dark));
+        a.recycle();
+
+        View snackbarView = snackbarWarning.getView();
+        snackbarView.setBackgroundColor(backgroundColor);
+        snackbarWarning.setActionTextColor(accentColor);
+
+        TextView snackbarText = (TextView)snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+        if (snackbarText != null) {
+            snackbarText.setTextColor(textColor);
+            snackbarText.setMaxLines(5);
+        }
+    }
+
+    private Snackbar.Callback snackbarListener = new Snackbar.Callback()
+    {
+        @Override
+        public void onDismissed(Snackbar snackbar, int event)
+        {
+            super.onDismissed(snackbar, event);
+            switch (event)
+            {
+                case DISMISS_EVENT_SWIPE:
+                    wasDismissed = true;
+                    showNextWarning();
+                    break;
+            }
+        }
+    };
+
+    private void showNextWarning()
+    {
+        if (warningListener != null) {
+            warningListener.onShowNextWarning();
+        }
+    }
+
+    public boolean isShown()
+    {
+        return (snackbar != null && snackbar.isShown());
+    }
+
+    public void show()
+    {
+        if (snackbar != null) {
+            snackbar.show();
+        }
+        announceWarning();
+    }
+
+    public void dismiss()
+    {
+        if (isShown()) {
+            snackbar.dismiss();
+        }
+    }
+
+    public void reset()
+    {
+        wasDismissed = false;
+        shouldShow = false;
+    }
+
+    public void setContentDescription( String value )
+    {
+        this.contentDescription = value;
+        TextView snackText = (TextView) snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+        if (snackText != null)
+        {
+            snackText.setContentDescription(contentDescription);
+        }
+    }
+
+    public void announceWarning()
+    {
+        if (parentView != null && contentDescription != null)
+        {
+            parentView.postDelayed(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    SuntimesUtils.announceForAccessibility(parentView, contentDescription);
+                }
+            }, ANNOUNCE_DELAY_MS);
+        }
+    }
+
+    public void save( Bundle outState )
+    {
+        if (outState != null)
+        {
+            outState.putBoolean(KEY_WASDISMISSED + id, wasDismissed);
+        }
+    }
+
+    public void restore( Bundle savedState )
+    {
+        if (savedState != null)
+        {
+            wasDismissed = savedState.getBoolean(KEY_WASDISMISSED + id, false);
+        }
+    }
+
+    public SuntimesWarningListener warningListener = null;
+    public void setWarningListener(SuntimesWarningListener listener) {
+        warningListener = listener;
+    }
+    public static abstract class SuntimesWarningListener {
+        public abstract void onShowNextWarning();
+    }
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -1039,8 +1039,15 @@ public class AlarmNotifications extends BroadcastReceiver
                     Log.d(TAG, "State Saved (onShow)");
                     if (item.type == AlarmClockItem.AlarmType.ALARM)
                     {
-                        showAlarmPlayingToast(getApplicationContext(), item);
-                        context.sendBroadcast(getFullscreenBroadcast(item.getUri()));   // update fullscreen activity
+                        if (!NotificationManagerCompat.from(context).areNotificationsEnabled())
+                        {
+                            // when notifications are disabled, fallback to directly starting the fullscreen activity
+                            startActivity(getFullscreenIntent(context, item.getUri()));
+
+                        } else {
+                            showAlarmPlayingToast(getApplicationContext(), item);
+                            context.sendBroadcast(getFullscreenBroadcast(item.getUri()));   // update fullscreen activity
+                        }
                     }
                 }
             };

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -33,6 +33,7 @@ public class AlarmSettings
 {
     public static final String PREF_KEY_ALARM_CATEGORY = "app_alarms_category";
     public static final String PREF_KEY_ALARM_BATTERYOPT = "app_alarms_batterytopt";
+    public static final String PREF_KEY_ALARM_NOTIFICATIONS = "app_alarms_notifications";
 
     public static final String PREF_KEY_ALARM_HARDAREBUTTON_ACTION = "app_alarms_hardwarebutton_action";
     public static final String PREF_DEF_ALARM_HARDAREBUTTON_ACTION = AlarmNotifications.ACTION_SNOOZE;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -34,6 +34,7 @@ public class AlarmSettings
     public static final String PREF_KEY_ALARM_CATEGORY = "app_alarms_category";
     public static final String PREF_KEY_ALARM_BATTERYOPT = "app_alarms_batterytopt";
     public static final String PREF_KEY_ALARM_NOTIFICATIONS = "app_alarms_notifications";
+    public static final String PREF_KEY_ALARM_VOLUMES = "app_alarms_volumes";
 
     public static final String PREF_KEY_ALARM_HARDAREBUTTON_ACTION = "app_alarms_hardwarebutton_action";
     public static final String PREF_DEF_ALARM_HARDAREBUTTON_ACTION = AlarmNotifications.ACTION_SNOOZE;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -41,6 +41,7 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -48,6 +49,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -65,6 +67,7 @@ import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.SuntimesActivity;
 import com.forrestguice.suntimeswidget.SuntimesSettingsActivity;
 import com.forrestguice.suntimeswidget.SuntimesUtils;
+import com.forrestguice.suntimeswidget.SuntimesWarning;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmDatabaseAdapter;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmClockItem;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmNotifications;
@@ -82,6 +85,7 @@ import com.forrestguice.suntimeswidget.themes.SuntimesTheme;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 
 /**
  * AlarmClockActivity
@@ -116,10 +120,15 @@ public class AlarmClockActivity extends AppCompatActivity
     private static final String KEY_LISTVIEW_TOP = "alarmlisttop";
     private static final String KEY_LISTVIEW_INDEX = "alarmlistindex";
 
+    public static final String WARNINGID_NOTIFICATIONS = "NotificationsWarning";
+
     private ActionBar actionBar;
     private ListView alarmList;
     private View emptyView;
     private FloatingActionButton addAlarmButton, addNotificationButton;
+
+    private SuntimesWarning notificationWarning;
+    private List<SuntimesWarning> warnings;
 
     private AlarmClockAdapter adapter = null;
     private Long t_selectedItem = null;
@@ -145,16 +154,17 @@ public class AlarmClockActivity extends AppCompatActivity
 
     /**
      * OnCreate: the Activity initially created
-     * @param icicle a Bundle containing saved state
+     * @param savedState a Bundle containing saved state
      */
     @Override
-    public void onCreate(Bundle icicle)
+    public void onCreate(Bundle savedState)
     {
         initTheme();
-        super.onCreate(icicle);
+        super.onCreate(savedState);
         initLocale(this);
         setContentView(R.layout.layout_activity_alarmclock);
         initViews(this);
+        initWarnings(this, savedState);
         handleIntent(getIntent());
     }
 
@@ -172,6 +182,59 @@ public class AlarmClockActivity extends AppCompatActivity
             Log.i("initTheme", "Overriding \"" + appTheme + "\" using: " + themeName);
             appThemeOverride = WidgetThemes.loadTheme(this, themeName);
         }
+    }
+
+    private void initWarnings(Context context, Bundle savedState)
+    {
+        notificationWarning = new SuntimesWarning(WARNINGID_NOTIFICATIONS);
+        warnings = new ArrayList<SuntimesWarning>();
+        warnings.add(notificationWarning);
+        restoreWarnings(savedState);
+    }
+    private SuntimesWarning.SuntimesWarningListener warningListener = new SuntimesWarning.SuntimesWarningListener() {
+        @Override
+        public void onShowNextWarning() {
+            showWarnings();
+        }
+    };
+    private void saveWarnings( Bundle outState )
+    {
+        for (SuntimesWarning warning : warnings) {
+            warning.save(outState);
+        }
+    }
+    private void restoreWarnings(Bundle savedState)
+    {
+        for (SuntimesWarning warning : warnings) {
+            warning.restore(savedState);
+            warning.setWarningListener(warningListener);
+        }
+    }
+    private void showWarnings()
+    {
+        boolean showWarnings = AppSettings.loadShowWarningsPref(this);
+        if (showWarnings && notificationWarning.shouldShow() && !notificationWarning.wasDismissed())
+        {
+            float iconSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 16, getResources().getDisplayMetrics());
+            notificationWarning.initWarning(this, alarmList, getString(R.string.notificationsWarning), iconSize);
+            notificationWarning.getSnackbar().setAction(getString(R.string.configLabel_alarms_notifications), new View.OnClickListener()
+            {
+                @Override
+                public void onClick(View view) {
+                    SuntimesSettingsActivity.openNotificationSettings(AlarmClockActivity.this);
+                }
+            });
+            notificationWarning.show();
+            return;
+        }
+
+        // no warnings shown; clear previous (stale) messages
+        notificationWarning.dismiss();
+    }
+    private void checkWarnings()
+    {
+        notificationWarning.setShouldShow(!NotificationManagerCompat.from(this).areNotificationsEnabled());
+        showWarnings();
     }
 
     @Override
@@ -342,6 +405,8 @@ public class AlarmClockActivity extends AppCompatActivity
                 offsetDialog.setOnAcceptedListener(onOffsetChanged);
             }
         } // else // TODO
+
+        checkWarnings();
     }
 
     @Override
@@ -367,6 +432,7 @@ public class AlarmClockActivity extends AppCompatActivity
     public void onSaveInstanceState( Bundle outState )
     {
         super.onSaveInstanceState(outState);
+        saveWarnings(outState);
         saveListViewPosition(outState);
 
         if (adapter != null) {
@@ -382,6 +448,7 @@ public class AlarmClockActivity extends AppCompatActivity
     public void onRestoreInstanceState(@NonNull Bundle savedState)
     {
         super.onRestoreInstanceState(savedState);
+        restoreWarnings(savedState);
         restoreListViewPosition(savedState);
 
         String idString = savedState.getString(KEY_SELECTED_ROWID);

--- a/app/src/main/res/layout/layout_activity_alarmclock.xml
+++ b/app/src/main/res/layout/layout_activity_alarmclock.xml
@@ -16,9 +16,10 @@
     You should have received a copy of the GNU General Public License
     along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:app="http://schemas.android.com/apk/res-auto"
-       xmlns:tools="http://schemas.android.com/tools">
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent" android:layout_height="match_parent">
 
 	<android.support.constraint.ConstraintLayout
 		android:layout_width="match_parent" android:layout_height="match_parent"
@@ -81,4 +82,4 @@
 		</LinearLayout>
 
 	</android.support.constraint.ConstraintLayout>
-</merge>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -681,7 +681,7 @@
     <string name="configLabel_alarms_notifications_off">Off.\nAlarms may fail to display correctly.</string>    <!-- TODO -->
     <string name="configLabel_alarms_notifications_summary0">%1$s</string>                    <!-- "On", "Off" --> <!-- TODO -->
     <string name="configLabel_alarms_notifications_summary1">On lock screen: %1$s</string>    <!-- "On lock screen: Off -->     <!-- TODO -->
-
+    <string name="notificationsWarning"><xliff:g id="warningTag">[w]</xliff:g> Notifications are off. Alarms may fail to display correctly.</string>  <!-- snackbar message -->    <!-- TODO -->
 
     <string name="configLabel_alarms_silenceAfter">Go silent after</string>
     <string name="configLabel_alarms_silenceAfter_summary"><xliff:g id="timePeriod" example="10 minutes">%s</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -678,9 +678,10 @@
 
     <string name="configLabel_alarms_notifications">Notifications</string>    <!-- TODO -->
     <string name="configLabel_alarms_notifications_on">On</string>    <!-- TODO -->
-    <string name="configLabel_alarms_notifications_off">Off</string>    <!-- TODO -->
+    <string name="configLabel_alarms_notifications_off">Off.\nAlarms may fail to display correctly.</string>    <!-- TODO -->
     <string name="configLabel_alarms_notifications_summary0">%1$s</string>                    <!-- "On", "Off" --> <!-- TODO -->
     <string name="configLabel_alarms_notifications_summary1">On lock screen: %1$s</string>    <!-- "On lock screen: Off -->     <!-- TODO -->
+
 
     <string name="configLabel_alarms_silenceAfter">Go silent after</string>
     <string name="configLabel_alarms_silenceAfter_summary"><xliff:g id="timePeriod" example="10 minutes">%s</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -676,6 +676,10 @@
     <string name="configLabel_alarms_optWhiteList_listed">Not optimized (recommended)</string>
     <string name="configLabel_alarms_optWhiteList_unlisted">Optimizing battery use.\nAlarms may be delayed up to 15 minutes.</string>
 
+    <string name="configLabel_alarms_notifications">Notifications</string>    <!-- TODO -->
+    <string name="configLabel_alarms_notifications_on">On</string>    <!-- TODO -->
+    <string name="configLabel_alarms_notifications_off">Off</string>    <!-- TODO -->
+
     <string name="configLabel_alarms_silenceAfter">Go silent after</string>
     <string name="configLabel_alarms_silenceAfter_summary"><xliff:g id="timePeriod" example="10 minutes">%s</xliff:g></string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -710,6 +710,7 @@
     </string-array>
 
     <string name="configLabel_alarmSounds">Sounds</string>            <!-- group title -->
+    <string name="configLabel_alarms_volumes">Volumes</string>    <!-- TODO -->
     <string name="configLabel_alarms_allRingtones">Show all ringtones</string>
     <string name="configLabel_alarms_allRingtones_summary">Show all system sounds during selection (ignore ringtone type).</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,6 +679,8 @@
     <string name="configLabel_alarms_notifications">Notifications</string>    <!-- TODO -->
     <string name="configLabel_alarms_notifications_on">On</string>    <!-- TODO -->
     <string name="configLabel_alarms_notifications_off">Off</string>    <!-- TODO -->
+    <string name="configLabel_alarms_notifications_summary0">%1$s</string>                    <!-- "On", "Off" --> <!-- TODO -->
+    <string name="configLabel_alarms_notifications_summary1">On lock screen: %1$s</string>    <!-- "On lock screen: Off -->     <!-- TODO -->
 
     <string name="configLabel_alarms_silenceAfter">Go silent after</string>
     <string name="configLabel_alarms_silenceAfter_summary"><xliff:g id="timePeriod" example="10 minutes">%s</xliff:g></string>

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -45,6 +45,11 @@
             android:title="@string/configLabel_alarms_optWhiteList"
             android:summary="@string/configLabel_alarms_optWhiteList_unlisted" />
 
+        <Preference
+            android:key="app_alarms_notifications" android:persistent="false"
+            android:title="@string/configLabel_alarms_notifications"
+            android:summary="@string/configLabel_alarms_notifications_on" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -55,6 +55,11 @@
     <PreferenceCategory
         android:title="@string/configLabel_alarmSounds" >
 
+        <Preference
+            android:key="app_alarms_volumes"
+            android:title="@string/configLabel_alarms_volumes"
+            android:summary="" />
+
         <CheckBoxPreference
             android:key="app_alarms_allringtones"
             android:title="@string/configLabel_alarms_allRingtones"

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -6,6 +6,22 @@
         android:title="@string/configLabel_alarmClock"
         android:key="app_alarms_category">
 
+        <Preference
+            android:key="app_alarms_batterytopt" android:persistent="false"
+            android:title="@string/configLabel_alarms_optWhiteList"
+            android:summary="@string/configLabel_alarms_optWhiteList_unlisted" />
+
+        <Preference
+            android:key="app_alarms_notifications" android:persistent="false"
+            android:title="@string/configLabel_alarms_notifications"
+            android:summary="@string/configLabel_alarms_notifications_on" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/configLabel_alarmClock"
+        android:key="app_alarms_category1">
+
         <com.forrestguice.suntimeswidget.settings.MillisecondPickerPreference
             android:key="app_alarms_upcomingMillis"
             android:title="@string/configLabel_alarms_upcoming"
@@ -39,16 +55,6 @@
             android:defaultValue="@string/def_app_alarms_hardwarebuttons_action"
             android:entryValues="@array/alarm_hardwarebutton_actions_values"
             android:entries="@array/alarm_hardwarebutton_actions_display" />-->
-
-        <Preference
-            android:key="app_alarms_batterytopt" android:persistent="false"
-            android:title="@string/configLabel_alarms_optWhiteList"
-            android:summary="@string/configLabel_alarms_optWhiteList_unlisted" />
-
-        <Preference
-            android:key="app_alarms_notifications" android:persistent="false"
-            android:title="@string/configLabel_alarms_notifications"
-            android:summary="@string/configLabel_alarms_notifications_on" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
* fixes bug "unable to dismiss alarm when notifications are disabled" (#333); now falls back to directly triggering the fullscreen activity.
* adds a "Notifications" warning to the AlarmClock activity that is shown if notifications are disabled. Notifications are required for alarms to display correctly (#333).
* adds a "Notifications" preference to the Alarm settings. This preference warns when notifications are disabled, or configured to not show on the lock screen (#332, #333).
* adds a "Volumes" preference to the Alarm settings (navigates to system Sound settings).
