### PR TITLE
release 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.11.6 (2019-06-24)
+* fixes bug "unable to dismiss alarm when notifications are disabled" (#333); now falls back to directly triggering the fullscreen activity.
+* adds a "Notifications" warning to the AlarmClock activity that is shown if notifications are disabled. Notifications are required for alarms to display correctly (#333).
+* adds a "Notifications" preference to the Alarm settings. This preference warns when notifications are disabled, or configured to not show on the lock screen (#332, #333).
+* adds a "Volumes" preference to the Alarm settings (navigates to system Sound settings).
+* updates translations to Polish (pl) and Esperanto (eo) (#330 by Verdulo).
+
 ### v0.11.5 (2019-05-31)
 * adds support for playing alarm sounds from the file system (mp3, ogg, etc). [Selecting files requires a file manager app with support for ringtone selection.] 
 * fixes bug "alarm sound fails to play from external storage" (#326); alarm notifications will fallback to the default ringtone if the selected sound cannot be played.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ### ~
 
 ### v0.11.6 (2019-06-24)
+* fixes bug "Suntimes Alarms uses elevation even if unchecked" (#336).
+* fixes bug "worldmap dialog fails to apply themed foreground color" (#337).
 * fixes bug "unable to dismiss alarm when notifications are disabled" (#333); now falls back to directly triggering the fullscreen activity.
 * adds a "Notifications" warning to the AlarmClock activity that is shown if notifications are disabled. Notifications are required for alarms to display correctly (#333).
 * adds a "Notifications" preference to the Alarm settings. This preference warns when notifications are disabled, or configured to not show on the lock screen (#332, #333).
 * adds a "Volumes" preference to the Alarm settings (navigates to system Sound settings).
-* updates translations to Polish (pl) and Esperanto (eo) (#330 by Verdulo).
+* optimizes basemaps and preview pngs; size reduced by ~50% using pngquant.
+* updates translations to Polish (pl) and Esperanto (eo) (#330, #339 by Verdulo).
 
 ### v0.11.5 (2019-05-31)
 * adds support for playing alarm sounds from the file system (mp3, ogg, etc). [Selecting files requires a file manager app with support for ringtone selection.] 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 46
-        versionName "0.11.5"
+        versionCode 47
+        versionName "0.11.6"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/47.txt
+++ b/fastlane/metadata/android/en-US/changelogs/47.txt
@@ -1,0 +1,6 @@
+* adds "Notifications" and "Volumes" preferences to the Alarm settings.
+* adds a warning to Suntimes Alarms when notifications are disabled. Notifications are required for alarms to display correctly (#333).
+* fixes bug "unable to dismiss alarm when notifications are disabled" (#333).
+* fixes bug "Suntimes Alarms uses elevation even if unchecked" (#336).
+* fixes bug "worldmap dialog fails to apply themed foreground color" (#337).
+* updates translations to Polish (pl) and Esperanto (eo).


### PR DESCRIPTION
* fixes bug "Suntimes Alarms uses elevation even if unchecked" (#336).
* fixes bug "worldmap dialog fails to apply themed foreground color" (#337).
* fixes bug "unable to dismiss alarm when notifications are disabled" (#333).
* adds a "Notifications" warning to the AlarmClock activity that is shown if notifications are disabled. Notifications are required for alarms to display correctly (#333).
* adds a "Notifications" preference to the Alarm settings. This preference warns when notifications are disabled, or configured to not show on the lock screen (#332, #333).
* adds a "Volumes" preference to the Alarm settings (navigates to system Sound settings).
* optimizes basemaps and preview pngs; size reduced by ~50% using pngquant.
* updates translations to Polish (pl) and Esperanto (eo) (#330, #339 by Verdulo).