### PR TITLE
release 0.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### ~
 
+### v0.11.8 (2019-07-30)
+* fixes bug "half hour and 45-minute time zones are listed incorrectly" (#346).
+* fixes bug "content provider uses a stale configuration" (#347).
+
 ### v0.11.7 (2019-07-08)
 * updates translations to Spanish (es-es) and Catalan (ca) (#340, #343 by Raulvo).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 48
-        versionName "0.11.7"
+        versionCode 49
+        versionName "0.11.8"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -1,0 +1,2 @@
+* fixes bug "half hour and 45-minute time zones are listed incorrectly" (#346).
+* fixes bug "content provider uses a stale configuration" (#347).


### PR DESCRIPTION
* fixes bug "half hour and 45-minute time zones are listed incorrectly" (#346).
* fixes bug "content provider uses a stale configuration" (#347).