### PR TITLE
release 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### ~
 
+### v0.12.3 (2019-12-02)
+* fixes bug "can't get location while gps is working and has a fix" (api17+) (#373).
+* improves the accuracy of gps results (applies a simple Kalman filter).
+* adds gps "recent max age" values "none" and "any" (ignores gps time when getting fix), and an option to fallback to the last location.
+* updates translation to Norwegian (nb) (#374 by FTno).
+
 ### v0.12.2 (2019-11-04)
 * fixes bug "Notifications don't respect Do Not Disturb" (#369).
 * updates translation to Norwegian (nb) (#370 by FTno).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### ~
 
-### v0.12.3 (2019-12-02)
+### v0.12.3 (2019-12-03)
 * fixes bug "can't get location while gps is working and has a fix" (api17+) (#373).
-* improves the accuracy of gps results (applies a simple Kalman filter).
 * adds gps "recent max age" values "none" and "any" (ignores gps time when getting fix), and an option to fallback to the last location.
+* improves the accuracy of gps results (applies a simple Kalman filter).
 * updates translation to Norwegian (nb) (#374 by FTno).
 
 ### v0.12.2 (2019-11-04)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 54
-        versionName "0.12.2"
+        versionCode 55
+        versionName "0.12.3"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/getfix/GetFixTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/getfix/GetFixTask.java
@@ -247,7 +247,7 @@ public class GetFixTask extends AsyncTask<Object, Location, Location>
             stopTime = System.currentTimeMillis();
             elapsedTime = stopTime - startTime;
 
-            if (bestFix != null && bestFix.getCount() >= 5 && elapsedTime > minElapsed) {
+            if (bestFix != null && elapsedTime > minElapsed) {
                 break;
             }
         }

--- a/fastlane/metadata/android/en-US/changelogs/55.txt
+++ b/fastlane/metadata/android/en-US/changelogs/55.txt
@@ -1,0 +1,4 @@
+* fixes bug "can't get location while gps is working and has a fix" (#373).
+* improves the accuracy of gps results (applies a simple Kalman filter).
+* adds gps "recent max age" values "none" and "any" (gps time is ignored), and an option to fallback to the last location.
+* updates translation to Norwegian (nb) (#374).

--- a/fastlane/metadata/android/en-US/changelogs/55.txt
+++ b/fastlane/metadata/android/en-US/changelogs/55.txt
@@ -1,4 +1,2 @@
 * fixes bug "can't get location while gps is working and has a fix" (#373).
-* improves the accuracy of gps results (applies a simple Kalman filter).
-* adds gps "recent max age" values "none" and "any" (gps time is ignored), and an option to fallback to the last location.
 * updates translation to Norwegian (nb) (#374).


### PR DESCRIPTION
* fixes bug "can't get location while gps is working and has a fix" (api17+) (#373).
* improves the accuracy of gps results (applies a simple Kalman filter).
* adds gps "recent max age" values "none" and "any" (ignores gps time when getting fix), and an option to fallback to the last location.
* updates translation to Norwegian (nb) (#374 by FTno).