### PR TITLE
release 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### ~
 
+### v0.12.4 (2019-12-23)
+* fixes app crash (time zone dialog) (#376).
+* fixes potentially long lived AsyncTask to run in parallel with shorter lived tasks (THREAD_POOL_EXECUTOR); "current location" updates no longer block dialogs from loading (#376).
+
 ### v0.12.3 (2019-12-03)
 * fixes bug "can't get location while gps is working and has a fix" (api17+) (#373).
 * adds gps "recent max age" values "none" and "any" (ignores gps time when getting fix), and an option to fallback to the last location.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### v0.12.4 (2019-12-23)
 * fixes app crash (time zone dialog) (#376).
-* fixes potentially long lived AsyncTask to run in parallel with shorter lived tasks (THREAD_POOL_EXECUTOR); "current location" updates no longer block dialogs from loading (#376).
+* fixes bug where updating "current location" blocks dialogs from loading; potentially long lived AsyncTask now run in parallel with shorter lived tasks (THREAD_POOL_EXECUTOR) (#376).
+* updates build; Android gradle plugin version updated to `com.android.tools.build:gradle:3.1.2`, gradle wrapper to `gradle-4.4`, and buildToolsVersion to `27.0.3`.
 
 ### v0.12.3 (2019-12-03)
 * fixes bug "can't get location while gps is working and has a fix" (api17+) (#373).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Widgets are resizable and include...
 * 3x1 sun position widget that displays the lightmap graph, and tracks the sun's altitude and azimuth (current, sunrise/sunset, and at noon).
 * 3x2 sun position widget that displays current sunlight and moonlight projected over a world map.
 
+<img width="128px" src="https://github.com/forrestguice/SuntimesWidget/blob/master/app/src/main/res/drawable-nodpi/clockwidget_1x1_preview.png" align="center"></img>
 <img width="128px" src="https://github.com/forrestguice/SuntimesWidget/blob/master/app/src/main/res/drawable-nodpi/widget1_preview.png" align="center"></img>
 <img width="128px" src="https://github.com/forrestguice/SuntimesWidget/blob/master/app/src/main/res/drawable-nodpi/widget0_1x1_preview.png" align="center"></img>
 <img width="288px" src="https://github.com/forrestguice/SuntimesWidget/blob/master/app/src/main/res/drawable-nodpi/widget0_2x1_preview.png" align="center"></img>
@@ -120,9 +121,9 @@ Version `0.9.*` contained the following additional permissions (removed in v0.10
 
 Do you find value in this software? Pay as you feel. 
 
-[![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2) [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=forrestguice&url=https://github.com/forrestguice/SuntimesWidget&title=Suntimes&tags=github&category=software)
+[![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2) 
 
-I want to express my thanks to those who have sent me something. This is a very meaningful gesture and greatly appreciated.
+I want to express my thanks to those who have sent me something. This is greatly appreciated.
 
 ## Bug Reports ##
 
@@ -134,7 +135,11 @@ When submitting a bug please be detailed and specific. What did you expect the a
 ## Legal Stuff
 
 Copyright &#169; 2014-2019 Forrest Guice<br/>
-The goal of this project is an app that is free and open-source (FOSS). The source code is available under *GPLv3* (https://github.com/forrestguice/SuntimesWidget).
+
+The source code is available under [GPLv3](LICENSE) (https://github.com/forrestguice/SuntimesWidget).
+> This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the [GNU General Public License](LICENSE) for more details.
+
+
 
 Icons and images from:
 * "Google Android Design Icons 20131120" [Apache License 2.0]

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 55
-        versionName "0.12.3"
+        versionCode 56
+        versionName "0.12.4"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/56.txt
+++ b/fastlane/metadata/android/en-US/changelogs/56.txt
@@ -1,2 +1,2 @@
 * fixes app crash (time zone dialog) (#376).
-* fixes bug where updating "current location" would block other dialogs from loading.
+* fixes bug where updating "current location" blocks dialogs from loading.

--- a/fastlane/metadata/android/en-US/changelogs/56.txt
+++ b/fastlane/metadata/android/en-US/changelogs/56.txt
@@ -1,0 +1,2 @@
+* fixes app crash (time zone dialog) (#376).
+* fixes bug where updating "current location" would block other dialogs from loading.


### PR DESCRIPTION
* fixes app crash (time zone dialog) (#376).
* fixes potentially long lived AsyncTask to run in parallel with shorter lived tasks (THREAD_POOL_EXECUTOR); "current location" updates no longer block dialogs from loading (#376).