### PR TITLE
release 0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.12.5 (2020-02-07)
+* adds a "dismiss" button to the reminder notification that allows repeating alarms to be dismissed early (reschedule+1); reveals the reminder notification for api21+ (#387).
+* fixes the appearance of ActionModes displayed within BottomSheetDialogFragment.
+* no longer reschedules alarms in response to TIME_SET broadcast.
+
 ### v0.12.4 (2019-12-23)
 * fixes app crash (time zone dialog) (#376).
 * fixes bug where updating "current location" blocks dialogs from loading; potentially long lived AsyncTask now run in parallel with shorter lived tasks (THREAD_POOL_EXECUTOR) (#376).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### ~
 
-### v0.12.5 (2020-02-07)
+### v0.12.5 (2020-02-08)
 * adds a "dismiss" button to the reminder notification that allows repeating alarms to be dismissed early (reschedule+1); reveals the reminder notification for api21+ (#387).
 * fixes the appearance of ActionModes displayed within BottomSheetDialogFragment.
+* fixes bug where ContentProvider would sometimes return uninitialized defaults.
 * no longer reschedules alarms in response to TIME_SET broadcast.
 
 ### v0.12.4 (2019-12-23)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 56
-        versionName "0.12.4"
+        versionCode 57
+        versionName "0.12.5"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/57.txt
+++ b/fastlane/metadata/android/en-US/changelogs/57.txt
@@ -1,0 +1,2 @@
+* adds a notification for dismissing repeating alarms early (#387).
+* fixes the appearance of "action modes" displayed by various dialogs.

--- a/fastlane/metadata/android/en-US/changelogs/57.txt
+++ b/fastlane/metadata/android/en-US/changelogs/57.txt
@@ -1,2 +1,2 @@
-* adds a notification for dismissing repeating alarms early (#387).
-* fixes the appearance of "action modes" displayed by various dialogs.
+- adds a notification for dismissing repeating alarms early (#387).
+- fixes the appearance of "action modes" displayed by various dialogs.


### PR DESCRIPTION
* adds a "dismiss" button to the reminder notification that allows repeating alarms to be dismissed early (reschedule+1); reveals the reminder notification for api21+ (#387).
* fixes the appearance of ActionModes displayed within BottomSheetDialogFragment.
* fixes bug where ContentProvider would sometimes return uninitialized defaults.
* no longer reschedules alarms in response to TIME_SET broadcast.