### PR TITLE
release 0.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### ~
 
 ### v0.12.7 (2020-04-06)
+* adds "gradually increase volume" option to Suntimes Alarms (#396).
 * fixes bug where CalculatorProvider fails to apply the selected time zone (#394).
+* updates translation to Brazilian Portuguese (pt-br) (#400 by efraletti).
 
 ### v0.12.6 (2020-03-16)
 * adds fields to CalculatorProvider that provide access to general app configuration (timeIs24, showSeconds, showHours, showWeeks, useElevation, showWarnings, verboseTalkback, showFields, lengthUnits, and objectHeight).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### ~
 
+### v0.12.7 (2020-04-06)
+* fixes bug where CalculatorProvider fails to apply the selected time zone (#394).
+
 ### v0.12.6 (2020-03-16)
 * adds fields to CalculatorProvider that provide access to general app configuration (timeIs24, showSeconds, showHours, showWeeks, useElevation, showWarnings, verboseTalkback, showFields, lengthUnits, and objectHeight).
 * fixes bug where CalculatorProvider would fail to honor changes to the calculator selection or "use elevation" option.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The app benefits from the following permissions...
 |BOOT_COMPLETED|To restore active alarms when the device boots.|v0.11.0|
 |READ_EXTERNAL_STORAGE|To play alarm sounds located on the SD card.|v0.11.5|
 |SET_ALARM|To interact with the system AlarmClock app.|v0.1.0|
-|WRITE_EXTERNAL_STORAGE|To export data (places, themes, etc.) to file.|v0.2.2 (api<=18)|
+|WRITE_EXTERNAL_STORAGE|To export data (places, themes, etc.) to file.|v0.2.2 (api&le;18)|
 
 Version `0.9.*` contained the following additional permissions (removed in v0.10.0)...
 
@@ -168,7 +168,7 @@ Basque translation by <u>beriain</u>.<br/>
 Norwegian translation by <u>FTno</u>.<br/>
 Italian translation by <u>Matteo Caoduro</u>.<br/>
 Traditional Chinese translation by <u><a href=https://github.com/pggdt>ft42</a></u>.<br />
-Brazilian Portuguese translation by <u><a href=https://github.com/netosilva15>NetoSilva</a></u> and <u>Nelson A. de Oliveira</u>.<br />
+Brazilian Portuguese translation by <u><a href=https://github.com/netosilva15>NetoSilva</a></u>, <u>Nelson A. de Oliveira</u>, and <u>Enrico S. B. Fraletti</u>.<br />
 
 [Contributions to the project](CONTRIBUTING.md) are welcome.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 58
-        versionName "0.12.6"
+        versionCode 59
+        versionName "0.12.7"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/59.txt
+++ b/fastlane/metadata/android/en-US/changelogs/59.txt
@@ -1,0 +1,1 @@
+- ContentProvider related bug fixes (#394).

--- a/fastlane/metadata/android/en-US/changelogs/59.txt
+++ b/fastlane/metadata/android/en-US/changelogs/59.txt
@@ -1,1 +1,3 @@
-- ContentProvider related bug fixes (#394).
+- adds "gradually increase volume" option to Suntimes Alarms.
+- updates translation to Brazilian Portuguese.
+- misc ContentProvider related bug fixes.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -10,6 +10,6 @@ The app benefits from the following permissions:
 * <small><u>SET_ALARM</u></small> is used to schedule alarms using the AlarmClock app.
 * <small><u>VIBRATE</u></small> is used by alarm notifications.
 * <small><u>READ_EXTERNAL_STORAGE</u></small> is used to play alarm sounds located on the SD card.
-* <small><u>WRITE_EXTERNAL_STORAGE</u></small> is used to backup data to file (places, themes, etc) <small>(api<=18 only)</small>.
+* <small><u>WRITE_EXTERNAL_STORAGE</u></small> is used to backup data to file (places, themes, etc) <small>(api&le;=18 only)</small>.
 
 Note: The "Calendar Integration" and permissions added in v0.9.0 were removed in v0.10.0. This feature is now available as a separate add-on app; <a href="https://f-droid.org/en/packages/com.forrestguice.suntimescalendars">Suntimes Calendars</a>.


### PR DESCRIPTION
* adds "gradually increase volume" option to Suntimes Alarms (#396).
* fixes bug where CalculatorProvider fails to apply the selected time zone (#394).
* updates translation to Brazilian Portuguese (pt-br) (#400 by efraletti).