### PR TITLE
solar alarm

### DIFF
--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItem.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItem.java
@@ -333,4 +333,99 @@ public class AlarmClockItem
         }
     }
 
+    /**
+     * AlarmTimeZone
+     */
+    public static enum AlarmTimeZone
+    {
+        SYSTEM_TIME("System Time Zone", null),
+        APPARENT_SOLAR_TIME(WidgetTimezones.ApparentSolarTime.TIMEZONEID, WidgetTimezones.ApparentSolarTime.TIMEZONEID),
+        LOCAL_MEAN_TIME(WidgetTimezones.LocalMeanTime.TIMEZONEID, WidgetTimezones.LocalMeanTime.TIMEZONEID);
+
+        private String displayString;
+        private String tzID;
+
+        private AlarmTimeZone(String displayString, String tzID)
+        {
+            this.displayString = displayString;
+            this.tzID = tzID;
+        }
+
+        public String timeZoneID() {
+            return tzID;
+        }
+
+        public String toString()
+        {
+            return displayString;
+        }
+
+        public String displayString() {
+            return displayString;
+        }
+
+        public static String displayString(String tzID)
+        {
+            if (tzID == null) {
+                return SYSTEM_TIME.displayString();
+
+            } else if (tzID.equals(APPARENT_SOLAR_TIME.timeZoneID())) {
+                return APPARENT_SOLAR_TIME.displayString();
+
+            } else if (tzID.equals(LOCAL_MEAN_TIME.timeZoneID())) {
+                return LOCAL_MEAN_TIME.displayString;
+
+            } else {
+                return TimeZone.getTimeZone(tzID).getDisplayName();
+            }
+        }
+
+        public void setDisplayString( String displayString ) {
+            this.displayString = displayString;
+        }
+
+        public static void initDisplayStrings( Context context )
+        {
+            SYSTEM_TIME.setDisplayString(context.getString(R.string.timeFormatMode_system));
+            LOCAL_MEAN_TIME.setDisplayString(context.getString(R.string.solartime_localMean));
+            APPARENT_SOLAR_TIME.setDisplayString(context.getString(R.string.solartime_apparent));
+        }
+
+        public TimeZone getTimeZone(Location location) {
+            return AlarmTimeZone.getTimeZone(timeZoneID(), location);
+        }
+
+        public static TimeZone getTimeZone(String tzID, Location location)
+        {
+            if (location == null || tzID == null) {
+                return TimeZone.getDefault();
+
+            } else if (tzID.equals(APPARENT_SOLAR_TIME.timeZoneID())) {
+                return new WidgetTimezones.ApparentSolarTime(location.getLongitudeAsDouble(), APPARENT_SOLAR_TIME.displayString());
+
+            } else if (tzID.equals(LOCAL_MEAN_TIME.timeZoneID())) {
+                return new WidgetTimezones.LocalMeanTime(location.getLongitudeAsDouble(), LOCAL_MEAN_TIME.displayString());
+
+            } else {
+                return TimeZone.getTimeZone(tzID);
+            }
+        }
+
+        public static AlarmTimeZone valueOfID(String tzID)
+        {
+            if (tzID == null) {
+                return SYSTEM_TIME;
+
+            } else if (tzID.equals(APPARENT_SOLAR_TIME.timeZoneID())) {
+                return APPARENT_SOLAR_TIME;
+
+            } else if (tzID.equals(LOCAL_MEAN_TIME.timeZoneID())) {
+                return LOCAL_MEAN_TIME;
+
+            } else {
+                return null;
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItem.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItem.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2019 Forrest Guice
+    Copyright (C) 2018-2020 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -22,21 +22,19 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.forrestguice.suntimeswidget.R;
-import com.forrestguice.suntimeswidget.alarmclock.ui.AlarmClockActivity;
-import com.forrestguice.suntimeswidget.calculator.SuntimesMoonData;
-import com.forrestguice.suntimeswidget.calculator.SuntimesRiseSetData;
 import com.forrestguice.suntimeswidget.calculator.core.Location;
 import com.forrestguice.suntimeswidget.settings.SolarEvents;
 import com.forrestguice.suntimeswidget.settings.WidgetSettings;
+import com.forrestguice.suntimeswidget.settings.WidgetTimezones;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
  * AlarmClockItem
@@ -60,6 +58,7 @@ public class AlarmClockItem
     public long offset = 0;
     public String label = null;
     public SolarEvents event = null;
+    public String timezone = null;
     public Location location = null;
     public String ringtoneName = null;
     public String ringtoneURI = null;
@@ -103,6 +102,8 @@ public class AlarmClockItem
         String eventString = alarm.getAsString(AlarmDatabaseAdapter.KEY_ALARM_SOLAREVENT);
         event = SolarEvents.valueOf(eventString, null);
 
+        timezone = alarm.getAsString(AlarmDatabaseAdapter.KEY_ALARM_TIMEZONE);
+
         vibrate = (alarm.getAsInteger(AlarmDatabaseAdapter.KEY_ALARM_VIBRATE) == 1);
         ringtoneName = alarm.getAsString(AlarmDatabaseAdapter.KEY_ALARM_RINGTONE_NAME);
         ringtoneURI = alarm.getAsString(AlarmDatabaseAdapter.KEY_ALARM_RINGTONE_URI);
@@ -136,6 +137,10 @@ public class AlarmClockItem
         if (event != null) {
             values.put(AlarmDatabaseAdapter.KEY_ALARM_SOLAREVENT, event.name());
         } else values.putNull(AlarmDatabaseAdapter.KEY_ALARM_SOLAREVENT);
+
+        if (timezone != null) {
+            values.put(AlarmDatabaseAdapter.KEY_ALARM_TIMEZONE, timezone);
+        } else values.putNull(AlarmDatabaseAdapter.KEY_ALARM_TIMEZONE);
 
         if (repeatingDays != null) {
             values.put(AlarmDatabaseAdapter.KEY_ALARM_REPEATING_DAYS, getRepeatingDays());

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItem.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItem.java
@@ -338,9 +338,9 @@ public class AlarmClockItem
      */
     public static enum AlarmTimeZone
     {
-        SYSTEM_TIME("System Time Zone", null),
         APPARENT_SOLAR_TIME(WidgetTimezones.ApparentSolarTime.TIMEZONEID, WidgetTimezones.ApparentSolarTime.TIMEZONEID),
-        LOCAL_MEAN_TIME(WidgetTimezones.LocalMeanTime.TIMEZONEID, WidgetTimezones.LocalMeanTime.TIMEZONEID);
+        LOCAL_MEAN_TIME(WidgetTimezones.LocalMeanTime.TIMEZONEID, WidgetTimezones.LocalMeanTime.TIMEZONEID),
+        SYSTEM_TIME("System Time Zone", null);
 
         private String displayString;
         private String tzID;
@@ -386,7 +386,7 @@ public class AlarmClockItem
 
         public static void initDisplayStrings( Context context )
         {
-            SYSTEM_TIME.setDisplayString(context.getString(R.string.timeFormatMode_system));
+            SYSTEM_TIME.setDisplayString(context.getString(R.string.timezoneMode_current));
             LOCAL_MEAN_TIME.setDisplayString(context.getString(R.string.solartime_localMean));
             APPARENT_SOLAR_TIME.setDisplayString(context.getString(R.string.solartime_apparent));
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapter.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapter.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2019 Forrest Guice
+    Copyright (C) 2018-2020 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -30,8 +30,6 @@ import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import com.forrestguice.suntimeswidget.settings.WidgetSettings;
-
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +38,7 @@ import java.util.List;
 public class AlarmDatabaseAdapter
 {
     public static final String DATABASE_NAME = "suntimesAlarms";
-    public static final int DATABASE_VERSION = 1;
+    public static final int DATABASE_VERSION = 2;
 
     //
     // Table: Alarms
@@ -80,6 +78,9 @@ public class AlarmDatabaseAdapter
 
     public static final String KEY_ALARM_SOLAREVENT = "event";                                      // SolarEvent ENUM (optional), the ALARM_DATETIME may be (re)calculated using this value
     public static final String DEF_ALARM_SOLAREVENT = KEY_ALARM_SOLAREVENT + " text";
+
+    public static final String KEY_ALARM_TIMEZONE = "timezone";                                     // TZ_ID or AlarmTimeDialogMode ENUM (optional); timezone is used when SOLAREVENT is null
+    public static final String DEF_ALARM_TIMEZONE = KEY_ALARM_TIMEZONE + " text";
 
     public static final String KEY_ALARM_PLACELABEL = "place";                                      // place label (optional), the ALARM_LABEL may include this value
     public static final String DEF_ALARM_PLACELABEL = KEY_ALARM_PLACELABEL + " text";
@@ -127,16 +128,20 @@ public class AlarmDatabaseAdapter
 
                                                          + DEF_ALARM_VIBRATE + ", "
                                                          + DEF_ALARM_RINGTONE_NAME + ", "
-                                                         + DEF_ALARM_RINGTONE_URI;
+                                                         + DEF_ALARM_RINGTONE_URI + ", "
+
+                                                         + DEF_ALARM_TIMEZONE;
 
     private static final String TABLE_ALARMS_CREATE = "create table " + TABLE_ALARMS + " (" + TABLE_ALARMS_CREATE_COLS + ");";
+    private static final String[] TABLE_ALARMS_UPGRADE_1_2 = new String[] { "alter table " + TABLE_ALARMS + " add column " + DEF_ALARM_TIMEZONE };
 
     private static final String[] QUERY_ALARMS_MINENTRY = new String[] { KEY_ROWID, KEY_ALARM_TYPE, KEY_ALARM_ENABLED, KEY_ALARM_DATETIME, KEY_ALARM_LABEL };
     private static final String[] QUERY_ALARMS_FULLENTRY = new String[] { KEY_ROWID, KEY_ALARM_TYPE, KEY_ALARM_ENABLED, KEY_ALARM_LABEL,
                                                                           KEY_ALARM_REPEATING, KEY_ALARM_REPEATING_DAYS,
                                                                           KEY_ALARM_DATETIME_ADJUSTED, KEY_ALARM_DATETIME, KEY_ALARM_DATETIME_HOUR, KEY_ALARM_DATETIME_MINUTE, KEY_ALARM_DATETIME_OFFSET,
                                                                           KEY_ALARM_SOLAREVENT, KEY_ALARM_PLACELABEL, KEY_ALARM_LATITUDE, KEY_ALARM_LONGITUDE, KEY_ALARM_ALTITUDE,
-                                                                          KEY_ALARM_VIBRATE, KEY_ALARM_RINGTONE_NAME, KEY_ALARM_RINGTONE_URI };
+                                                                          KEY_ALARM_VIBRATE, KEY_ALARM_RINGTONE_NAME, KEY_ALARM_RINGTONE_URI,
+                                                                          KEY_ALARM_TIMEZONE };
 
     //
     // Table: AlarmState
@@ -314,6 +319,7 @@ public class AlarmDatabaseAdapter
                 KEY_ALARM_REPEATING + separator +
                 KEY_ALARM_REPEATING_DAYS + separator +
                 KEY_ALARM_SOLAREVENT + separator +
+                KEY_ALARM_TIMEZONE + separator +
                 KEY_ALARM_PLACELABEL + separator +
                 KEY_ALARM_LATITUDE + separator +
                 KEY_ALARM_LONGITUDE + separator +
@@ -338,6 +344,7 @@ public class AlarmDatabaseAdapter
                       alarm.getAsInteger(KEY_ALARM_REPEATING) + separator +
                       quote + alarm.getAsString(KEY_ALARM_REPEATING_DAYS) + quote + separator +
                       alarm.getAsString(KEY_ALARM_SOLAREVENT) + separator +
+                      alarm.getAsString(KEY_ALARM_TIMEZONE) + separator +
                       quote + alarm.getAsString(KEY_ALARM_PLACELABEL) + quote + separator +
                       alarm.getAsString(KEY_ALARM_LATITUDE) + separator +
                       alarm.getAsString(KEY_ALARM_LONGITUDE) + separator +
@@ -397,14 +404,18 @@ public class AlarmDatabaseAdapter
         @Override
         public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion)
         {
-            /**Log.w("GetFixDatabaseAdapter", "Upgrading database from version " + oldVersion + " to " + newVersion);
-            switch (oldVersion)
+            Log.w("AlarmDatabaseAdapter", "Upgrading database from version " + oldVersion + " to " + newVersion);
+            if (oldVersion == 1)
             {
-                case 1:
-                case 2:
-                case 3:
-                    break;
-            }*/
+                switch (newVersion)
+                {
+                    case 2:
+                        for (int i=0; i<TABLE_ALARMS_UPGRADE_1_2.length; i++) {
+                            db.execSQL(TABLE_ALARMS_UPGRADE_1_2[i]);
+                        }
+                        break;
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapter.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapter.java
@@ -79,7 +79,7 @@ public class AlarmDatabaseAdapter
     public static final String KEY_ALARM_SOLAREVENT = "event";                                      // SolarEvent ENUM (optional), the ALARM_DATETIME may be (re)calculated using this value
     public static final String DEF_ALARM_SOLAREVENT = KEY_ALARM_SOLAREVENT + " text";
 
-    public static final String KEY_ALARM_TIMEZONE = "timezone";                                     // TZ_ID or AlarmTimeDialogMode ENUM (optional); timezone is used when SOLAREVENT is null
+    public static final String KEY_ALARM_TIMEZONE = "timezone";                                     // TZ_ID; applied to clock time when SOLAREVENT is null
     public static final String DEF_ALARM_TIMEZONE = KEY_ALARM_TIMEZONE + " text";
 
     public static final String KEY_ALARM_PLACELABEL = "place";                                      // place label (optional), the ALARM_LABEL may include this value

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -72,6 +72,7 @@ import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.List;
+import java.util.TimeZone;
 
 public class AlarmNotifications extends BroadcastReceiver
 {
@@ -1381,7 +1382,7 @@ public class AlarmNotifications extends BroadcastReceiver
                     break;
             }
         } else {
-            eventTime = updateAlarmTime_clockTime(item.hour, item.minute, item.offset, item.repeating, item.repeatingDays, now);
+            eventTime = updateAlarmTime_clockTime(item.hour, item.minute, item.timezone, item.location, item.offset, item.repeating, item.repeatingDays, now);
         }
 
         if (eventTime == null) {
@@ -1547,10 +1548,13 @@ public class AlarmNotifications extends BroadcastReceiver
     }
 
     @Nullable
-    private static Calendar updateAlarmTime_clockTime(int hour, int minute, long offset, boolean repeating, ArrayList<Integer> repeatingDays, Calendar now)
+    private static Calendar updateAlarmTime_clockTime(int hour, int minute, String tzID, @Nullable Location location, long offset, boolean repeating, ArrayList<Integer> repeatingDays, Calendar now)
     {
-        Calendar alarmTime = Calendar.getInstance();
-        Calendar eventTime = Calendar.getInstance();
+        TimeZone timezone = AlarmClockItem.AlarmTimeZone.getTimeZone(tzID, location);
+        Log.d(TAG, "updateAlarmTime_clockTime: using timezone " + timezone.getID());
+
+        Calendar alarmTime = Calendar.getInstance(timezone);
+        Calendar eventTime = Calendar.getInstance(timezone);
 
         eventTime.set(Calendar.SECOND, 0);
         if (hour >= 0 && hour < 24) {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2019 Forrest Guice
+    Copyright (C) 2018-2020 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -933,6 +933,7 @@ public class AlarmClockActivity extends AppCompatActivity
 
             AlarmTimeDialog timeDialog = new AlarmTimeDialog();
             timeDialog.setTime(hour, minute);
+            timeDialog.setTimeZone(item.timezone);
             timeDialog.set24Hour(SuntimesUtils.is24());
             timeDialog.setOnAcceptedListener(onTimeChanged);
             t_selectedItem = item.rowID;
@@ -959,6 +960,7 @@ public class AlarmClockActivity extends AppCompatActivity
                 item.event = null;
                 item.hour = timeDialog.getHour();
                 item.minute = timeDialog.getMinute();
+                item.timezone = timeDialog.getTimeZone();
                 item.modified = true;
                 AlarmNotifications.updateAlarmTime(AlarmClockActivity.this, item);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -330,6 +330,8 @@ public class AlarmClockActivity extends AppCompatActivity
         WidgetSettings.initDisplayStrings(context);
         SuntimesUtils.initDisplayStrings(context);
         SolarEvents.initDisplayStrings(context);
+        AlarmClockItem.AlarmType.initDisplayStrings(context);
+        AlarmClockItem.AlarmTimeZone.initDisplayStrings(context);
 
         int[] attrs = { R.attr.alarmColorEnabled, android.R.attr.textColorPrimary, R.attr.text_disabledColor, R.attr.buttonPressColor, android.R.attr.textColor, R.attr.icActionNew, R.attr.icActionClose };
         TypedArray a = context.obtainStyledAttributes(attrs);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockAdapter.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockAdapter.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2019 Forrest Guice
+    Copyright (C) 2018-2020 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -32,13 +32,11 @@ import android.graphics.drawable.LayerDrawable;
 import android.os.Build;
 import android.os.Vibrator;
 import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.ColorUtils;
 import android.support.v4.widget.CompoundButtonCompat;
 import android.support.v4.widget.ImageViewCompat;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.widget.AppCompatCheckBox;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.SwitchCompat;
 import android.text.Spannable;
@@ -538,7 +536,7 @@ public class AlarmClockAdapter extends ArrayAdapter<AlarmClockItem>
         }
 
         // location
-        view.text_location.setVisibility(item.event == null ? View.INVISIBLE : View.VISIBLE);
+        view.text_location.setVisibility((item.event == null && item.timezone == null) ? View.INVISIBLE : View.VISIBLE);
         AlarmDialog.updateLocationLabel(context, view.text_location, item.location);
 
         if (!isSelected || item.enabled) {
@@ -839,7 +837,19 @@ public class AlarmClockAdapter extends ArrayAdapter<AlarmClockItem>
 
     private static CharSequence getAlarmEvent(Context context, AlarmClockItem item)
     {
-        return (item.event != null ? item.event.getLongDisplayString() : context.getString(R.string.alarmOption_solarevent_none));
+        if (item.event != null)
+        {
+            return item.event.getLongDisplayString();
+
+        } else if (item.timezone != null) {
+            Calendar adjustedTime = Calendar.getInstance(AlarmClockItem.AlarmTimeZone.getTimeZone(item.timezone, item.location));
+            adjustedTime.set(Calendar.HOUR_OF_DAY, item.hour);
+            adjustedTime.set(Calendar.MINUTE, item.minute);
+            return utils.calendarTimeShortDisplayString(context, adjustedTime) + "\n" + AlarmClockItem.AlarmTimeZone.displayString(item.timezone);
+
+        } else {
+            return context.getString(R.string.alarmOption_solarevent_none);
+        }
     }
 
     private static CharSequence getAlarmTime(Context context, AlarmClockItem item)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
@@ -521,6 +521,7 @@ public class AlarmDismissActivity extends AppCompatActivity
         }
     };
 
+    @SuppressLint("SetTextI18n")
     public void setAlarmItem(@NonNull Context context, @NonNull AlarmClockItem item)
     {
         alarm = item;
@@ -532,7 +533,19 @@ public class AlarmDismissActivity extends AppCompatActivity
             alarmSubtitle.setText(item.event.getLongDisplayString());
             alarmSubtitle.setVisibility(View.VISIBLE);
 
-        } else alarmSubtitle.setVisibility(View.GONE);
+        } else {
+            if (alarm.timezone != null)
+            {
+                Calendar eventTime = Calendar.getInstance(AlarmClockItem.AlarmTimeZone.getTimeZone(item.timezone, item.location));
+                eventTime.set(Calendar.HOUR_OF_DAY, item.hour);
+                eventTime.set(Calendar.MINUTE, item.minute);
+                alarmSubtitle.setText(utils.calendarTimeShortDisplayString(context, eventTime) + "\n" + AlarmClockItem.AlarmTimeZone.displayString(item.timezone));
+                alarmSubtitle.setVisibility(View.VISIBLE);
+
+            } else {
+                alarmSubtitle.setVisibility(View.GONE);
+            }
+        }
 
         Spannable offsetSpan = new SpannableString("");
         if (item.offset != 0)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
@@ -264,6 +264,7 @@ public class AlarmDismissActivity extends AppCompatActivity
         WidgetSettings.initDisplayStrings(context);
         SuntimesUtils.initDisplayStrings(context);
         SolarEvents.initDisplayStrings(context);
+        AlarmClockItem.AlarmTimeZone.initDisplayStrings(context);
 
         int[] attrs = { R.attr.sunsetColor,  R.attr.sunriseColor, R.attr.dialogBackgroundAlt,
                 R.attr.text_disabledColor, R.attr.buttonPressColor, R.attr.text_disabledColor,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmTimeDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmTimeDialog.java
@@ -132,6 +132,7 @@ public class AlarmTimeDialog extends DialogFragment
 
     protected void initViews( final Context context, View dialogContent )
     {
+        AlarmClockItem.AlarmTimeZone.initDisplayStrings(context);
         modeAdapter = new ArrayAdapter<>(context, R.layout.layout_listitem_oneline, AlarmClockItem.AlarmTimeZone.values());
         modeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         modePicker = (Spinner)dialogContent.findViewById(R.id.modepicker);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmTimeDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmTimeDialog.java
@@ -232,7 +232,9 @@ public class AlarmTimeDialog extends DialogFragment
         this.is24 =  bundle.getBoolean(PREF_KEY_ALARM_TIME_24HR, PREF_DEF_ALARM_TIME_24HR);
         this.hour =  bundle.getInt(PREF_KEY_ALARM_TIME_HOUR, PREF_DEF_ALARM_TIME_HOUR);
         this.minute = bundle.getInt(PREF_KEY_ALARM_TIME_MINUTE, PREF_DEF_ALARM_TIME_MINUTE);
-        this.mode = AlarmClockItem.AlarmTimeZone.valueOf(bundle.getString(PREF_KEY_ALARM_TIME_MODE, PREF_DEF_ALARM_TIME_MODE.name()));
+
+        String modeString = bundle.getString(PREF_KEY_ALARM_TIME_MODE);
+        this.mode = ((modeString != null) ? AlarmClockItem.AlarmTimeZone.valueOf(modeString) : PREF_DEF_ALARM_TIME_MODE);
     }
 
     protected void saveSettings(Bundle bundle)

--- a/app/src/main/res/layout-land/layout_dialog_alarmtime.xml
+++ b/app/src/main/res/layout-land/layout_dialog_alarmtime.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2018-2020 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent" android:layout_height="wrap_content"
+    android:paddingLeft="?dialogPreferredPadding" android:paddingRight="?dialogPreferredPadding"
+    android:paddingTop="8dp" android:paddingBottom="8dp"
+    android:orientation="horizontal">
+
+    <TimePicker
+        android:id="@+id/timepicker"
+        android:timePickerMode="spinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end" />
+
+    <android.support.v7.widget.AppCompatSpinner
+        android:id="@+id/modepicker"
+        android:layout_width="0dp" android:layout_weight="1" android:minWidth="200dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|center_vertical"
+        tools:text="System Time Zone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/layout_dialog_alarmtime.xml
+++ b/app/src/main/res/layout/layout_dialog_alarmtime.xml
@@ -25,19 +25,19 @@
         android:paddingTop="8dp" android:paddingBottom="8dp"
         android:orientation="vertical">
 
-        <TimePicker
-            android:id="@+id/timepicker"
-            android:timePickerMode="spinner"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_gravity="end" />
-
         <android.support.v7.widget.AppCompatSpinner
             android:id="@+id/modepicker"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             tools:text="System Time Zone" />
+
+        <TimePicker
+            android:id="@+id/timepicker"
+            android:timePickerMode="spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/layout_dialog_alarmtime.xml
+++ b/app/src/main/res/layout/layout_dialog_alarmtime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (C) 2018 Forrest Guice
+    Copyright (C) 2018-2020 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -16,17 +16,31 @@
     You should have received a copy of the GNU General Public License
     along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent" android:layout_height="wrap_content"
-    android:paddingLeft="?dialogPreferredPadding" android:paddingRight="?dialogPreferredPadding"
-    android:paddingTop="8dp" android:paddingBottom="8dp"
-    android:orientation="vertical">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent" android:layout_height="match_parent">
 
-    <TimePicker
-        android:id="@+id/timepicker"
-        android:timePickerMode="spinner"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent" />
+    <LinearLayout
+        android:layout_width="fill_parent" android:layout_height="wrap_content"
+        android:paddingLeft="?dialogPreferredPadding" android:paddingRight="?dialogPreferredPadding"
+        android:paddingTop="8dp" android:paddingBottom="8dp"
+        android:orientation="vertical">
 
-</LinearLayout>
+        <TimePicker
+            android:id="@+id/timepicker"
+            android:timePickerMode="spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="end" />
+
+        <android.support.v7.widget.AppCompatSpinner
+            android:id="@+id/modepicker"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            tools:text="System Time Zone" />
+
+    </LinearLayout>
+
+</ScrollView>
+
 


### PR DESCRIPTION
Allow for scheduling alarms by solar time (implements #403):
* adds `timezone` field to alarm database (and applies it when scheduling clock time).
* adds time zone spinner to AlarmTimeDialog; limit selection ("System", "Apparent Solar", "Local Mean").
* modifies UI (AlarmClockAdapter, AlarmDismissActivity) to display selected time zone.