### PR TITLE
release 0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.12.8 (2020-04-29)
+### v0.12.8 (2020-04-30)
 * adds ability to set an alarm in solar time (#403); adds `timezone` field to alarm item database; increments database version (`1` -> `2`).
 * adds field to CalculatorProvider; `COLUMN_CONFIG_APP_THEME_OVERRIDE`; increments CalculatorProvider versionCode (`3` -> `4`).
 * adds a ContentProvider (SuntimesThemeProvider) that provides access to user-defined themes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.12.8 (2020-04-29)
+* adds ability to set an alarm in solar time (#403); adds `timezone` field to alarm item database; increments database version (`1` -> `2`).
+* adds field to CalculatorProvider; `COLUMN_CONFIG_APP_THEME_OVERRIDE`; increments CalculatorProvider versionCode (`3` -> `4`).
+* adds a ContentProvider (SuntimesThemeProvider) that provides access to user-defined themes.
+* exports the ThemeList activity; permits access to third-party apps with the `suntimes.permission.READ_CALCULATOR` permission.
+* fixes bug where NotificationService continues running after scheduling a notification or distant alarm.
+
 ### v0.12.7 (2020-04-12)
 * adds "gradually increase volume" option to Suntimes Alarms (#396).
 * fixes bug where CalculatorProvider fails to apply the selected time zone (#394).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Android app (and widget collection) that displays sunlight and moonlight times f
 
 [![F-Droid](https://img.shields.io/f-droid/v/com.forrestguice.suntimeswidget.svg)](https://f-droid.org/en/packages/com.forrestguice.suntimeswidget/)
 [![GitHub release](https://img.shields.io/github/release/forrestguice/SuntimesWidget.svg)](https://github.com/forrestguice/SuntimesWidget/releases)
-[![Build Status](https://travis-ci.org/forrestguice/SuntimesWidget.svg?branch=master)](https://travis-ci.org/forrestguice/SuntimesWidget)
+![Android CI](https://github.com/forrestguice/SuntimesWidget/workflows/Android%20CI/badge.svg?branch=master)
 
 * [Privacy and Permissions](#privacy-and-permissions)
 * [Donations](#donations)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 59
-        versionName "0.12.7"
+        versionCode 60
+        versionName "0.12.8"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/60.txt
+++ b/fastlane/metadata/android/en-US/changelogs/60.txt
@@ -1,0 +1,3 @@
+- adds ability to schedule alarms using solar time (#403).
+- improved integration for add-ons (adds ContentProvider to access user-defined themes).
+- fixes bug where the AlarmNotifications service continues running after scheduling is completed.


### PR DESCRIPTION
* adds ability to set an alarm in solar time (#403); adds `timezone` field to alarm item database; increments database version (`1` -> `2`).
* adds field to CalculatorProvider; `COLUMN_CONFIG_APP_THEME_OVERRIDE`; increments CalculatorProvider versionCode (`3` -> `4`).
* adds a ContentProvider (SuntimesThemeProvider) that provides access to user-defined themes.
* exports the ThemeList activity; permits access to third-party apps with the `suntimes.permission.READ_CALCULATOR` permission.
* fixes bug where NotificationService continues running after scheduling a notification or distant alarm.