### PR TITLE
release 0.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### ~
 
+### v0.12.11 (2020-06-16)
+* fixes bug "sun position widget does not render midnight sun" (#421).
+* fixes app crash when using fallback to "last location" (#420).
+
 ### v0.12.10 (2020-05-20)
 * fixes bug "solar time alarms are offset by several minutes" (#414).
 * updates translation to German (de) (#412 by xnumad).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 62
-        versionName "0.12.10"
+        versionCode 63
+        versionName "0.12.11"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/63.txt
+++ b/fastlane/metadata/android/en-US/changelogs/63.txt
@@ -1,0 +1,2 @@
+- fixes bug "sun position widget does not render midnight sun" (#421).
+- fixes app crash when using fallback to "last location" (#420).


### PR DESCRIPTION
* fixes bug "sun position widget does not render midnight sun" (fix #421).
* fixes app crash when using fallback to "last location" (fix #420).