### PR TITLE
release 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ### ~
 
 ### v0.13.2 (2020-10-26)
+* adds support for overriding location when creating alarms via Intent.
 * adds a hex color field to the rgb color picker.
 * fixes bug where ColorDialog sliders sometimes start with the wrong value.
 * fixes crash in AlarmClockActivity when notifications are disabled (#437).
 * fixes bug "incorrect future and past number of days, when DST starts or ends" (#436).
-* fixes warning icons (too small / unreadable) to be consistent across devices.
-* exports the WidgetListActivity, ActionListActivity, and SettingsActivity; permits access to third-party apps with the `suntimes.permission.READ_CALCULATOR` permission.
+* fixes spannable icons (too small / unreadable) to be consistent across devices.
 * improves organization of "User Interface" settings (#434).
+* exports the WidgetListActivity, ActionListActivity, and SettingsActivity; permits access to third-party apps with the `suntimes.permission.READ_CALCULATOR` permission.
+* enhances the WidgetListActivity to show add-on widgets (and allow reconfigure).
+* new permission: The app now uses `suntimes.permission.READ_CALCULATOR` (in addition to declaring it). Add-on apps may now use this permission to protect their own interfaces. [PERMISSION]
 
 ### v0.13.1 (2020-10-03)
 * minor tweaks to app help topics (#432).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### ~
 
+### v0.13.2 (2020-10-26)
+* adds a hex color field to the rgb color picker.
+* fixes bug where ColorDialog sliders sometimes start with the wrong value.
+* fixes crash in AlarmClockActivity when notifications are disabled (#437).
+* fixes bug "incorrect future and past number of days, when DST starts or ends" (#436).
+* fixes warning icons (too small / unreadable) to be consistent across devices.
+* exports the WidgetListActivity, ActionListActivity, and SettingsActivity; permits access to third-party apps with the `suntimes.permission.READ_CALCULATOR` permission.
+* improves organization of "User Interface" settings (#434).
+
 ### v0.13.1 (2020-10-03)
 * minor tweaks to app help topics (#432).
 * fixes bug where deleted locations would reappear ("no way to remove default location" #430).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 65
-        versionName "0.13.1"
+        versionCode 66
+        versionName "0.13.2"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/66.txt
+++ b/fastlane/metadata/android/en-US/changelogs/66.txt
@@ -1,6 +1,6 @@
 - fixes crash in SuntimesAlarms when notifications are disabled (#437).
 - fixes bug "incorrect future and past number of days, when DST starts or ends" (#436).
 - fixes bug where ColorDialog sliders sometimes start with the wrong value.
-- improves integration for add-ons; access now permitted to app settings, widget, and action lists.
+- improves integration for add-ons; exports activities, extends custom permission.
 - reorganizes "User Interface" settings (#434), and other misc UI fixes.
 - adds a hex color field to the rgb color picker.

--- a/fastlane/metadata/android/en-US/changelogs/66.txt
+++ b/fastlane/metadata/android/en-US/changelogs/66.txt
@@ -1,0 +1,6 @@
+- fixes crash in SuntimesAlarms when notifications are disabled (#437).
+- fixes bug "incorrect future and past number of days, when DST starts or ends" (#436).
+- fixes bug where ColorDialog sliders sometimes start with the wrong value.
+- improves integration for add-ons; access now permitted to app settings, widget, and action lists.
+- reorganizes "User Interface" settings (#434), and other misc UI fixes.
+- adds a hex color field to the rgb color picker.


### PR DESCRIPTION
* adds support for overriding location when creating alarms via Intent.
* adds a hex color field to the rgb color picker.
* fixes bug where ColorDialog sliders sometimes start with the wrong value.
* fixes crash in AlarmClockActivity when notifications are disabled (fixes #437).
* fixes bug "incorrect future and past number of days, when DST starts or ends" (fixes #436).
* fixes spannable icons (too small / unreadable) to be consistent across devices.
* improves organization of "User Interface" settings (#434).
* exports the WidgetListActivity, ActionListActivity, and SettingsActivity; permits access to third-party apps with the `suntimes.permission.READ_CALCULATOR` permission.
* enhances the WidgetListActivity to show add-on widgets (and allow reconfigure).
* **[permission]** The app now uses `suntimes.permission.READ_CALCULATOR` (in addition to declaring it). Add-on apps may now require this permission to protect their own interfaces.