### PR TITLE
widgetlist

### DIFF
--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivityTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivityTest.java
@@ -21,6 +21,7 @@ package com.forrestguice.suntimeswidget;
 import android.app.Activity;
 import android.content.Context;
 import android.preference.Preference;
+import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
 import android.support.test.espresso.DataInteraction;
@@ -440,7 +441,7 @@ public class SuntimesSettingsActivityTest extends SuntimesActivityTestBase
         verifyWidgetSettings(activity);
     }
 
-    public static void verifyWidgetSettings(Context context)
+    public static void verifyWidgetSettings(@NonNull Context context)
     {
         ArrayAdapter widgetAdapter = SuntimesWidgetListActivity.WidgetListAdapter.createWidgetListAdapter(context);
         if (widgetAdapter.isEmpty())

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <permission
         android:name="suntimes.permission.READ_CALCULATOR"
         android:protectionLevel="normal" />                       <!-- protects suntimeswidget.calculator.provider -->
+    <uses-permission android:name="suntimes.permission.READ_CALCULATOR" />
 
     <uses-sdk tools:overrideLibrary="com.flask.colorpicker" />
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -39,6 +39,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -412,18 +413,18 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
 
         @Override
         @NonNull
-        public View getView(int position, View convertView, @NonNull ViewGroup parent)
+        public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent)
         {
             return widgetItemView(position, convertView, parent);
         }
 
         @Override
-        public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent)
+        public View getDropDownView(int position, @Nullable View convertView, @NonNull ViewGroup parent)
         {
             return widgetItemView(position, convertView, parent);
         }
 
-        private View widgetItemView(int position, View convertView, @NonNull ViewGroup parent)
+        private View widgetItemView(int position, @Nullable View convertView, @NonNull ViewGroup parent)
         {
             View view = convertView;
             if (convertView == null)
@@ -452,7 +453,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             return view;
         }
 
-        public static ArrayList<WidgetListItem> createWidgetListItems(Context context, AppWidgetManager widgetManager, @NonNull String packageName, @NonNull String widgetClass)
+        public static ArrayList<WidgetListItem> createWidgetListItems(Context context, @NonNull AppWidgetManager widgetManager, @NonNull String packageName, @NonNull String widgetClass)
         {
             String titlePattern = getTitlePattern(context, widgetClass);
             ArrayList<WidgetListItem> items = new ArrayList<WidgetListItem>();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -249,7 +249,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
      * updateViews
      * @param context context
      */
-    protected void updateViews(Context context)
+    protected void updateViews(@NonNull Context context)
     {
         widgetList.setAdapter(WidgetListAdapter.createWidgetListAdapter(context));
     }
@@ -497,14 +497,14 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             return items;
         }
 
-        public static ArrayList<WidgetListItem> createWidgetListItems(Context context, @NonNull String contentUri)
+        public static ArrayList<WidgetListItem> createWidgetListItems(@NonNull Context context, @NonNull String contentUri)
         {
             if (!contentUri.endsWith("/")) {
                 contentUri += "/";
             }
 
             ArrayList<WidgetListItem> items = new ArrayList<WidgetListItem>();
-            ContentResolver resolver = (context == null ? null : context.getContentResolver());
+            ContentResolver resolver = context.getContentResolver();
             if (resolver != null)
             {
                 Uri uri = Uri.parse(contentUri + QUERY_WIDGET);
@@ -535,7 +535,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             return items;
         }
 
-        public static WidgetListAdapter createWidgetListAdapter(Context context)
+        public static WidgetListAdapter createWidgetListAdapter(@NonNull Context context)
         {
             AppWidgetManager widgetManager = AppWidgetManager.getInstance(context);
             ArrayList<WidgetListItem> items = new ArrayList<WidgetListItem>();
@@ -664,7 +664,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             COLUMN_WIDGET_LABEL, COLUMN_WIDGET_SUMMARY, COLUMN_WIDGET_ICON
     };
 
-    public static List<String> queryWidgetInfoProviders(Context context)
+    public static List<String> queryWidgetInfoProviders(@NonNull Context context)
     {
         ArrayList<String> references = new ArrayList<>();
         PackageManager packageManager = context.getPackageManager();
@@ -675,7 +675,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
 
         for (ResolveInfo resolveInfo : packages)
         {
-            if (resolveInfo.activityInfo != null && resolveInfo.activityInfo.metaData != null)
+            if (resolveInfo != null && resolveInfo.activityInfo != null && resolveInfo.activityInfo.metaData != null)
             {
                 try {
                     PackageInfo packageInfo = packageManager.getPackageInfo(resolveInfo.activityInfo.packageName, PackageManager.GET_PERMISSIONS);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -514,19 +514,35 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
                     cursor.moveToFirst();
                     while (!cursor.isAfterLast())
                     {
-                        int appWidgetID = cursor.getInt(cursor.getColumnIndex(COLUMN_WIDGET_APPWIDGETID));
-                        String packageName = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_PACKAGENAME));
-                        String widgetClass = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_CLASS));
-                        String configClass = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_CONFIGCLASS));
+                        try {
+                            int appWidgetID = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_WIDGET_APPWIDGETID));    // required
+                            String packageName = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_WIDGET_PACKAGENAME));    // required
+                            String widgetClass = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_WIDGET_CLASS));    //required
 
-                        String title = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_LABEL));
-                        String summary = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_SUMMARY));
+                            int i_configClass = cursor.getColumnIndex(COLUMN_WIDGET_CONFIGCLASS);   // optional
+                            String configClass = ((i_configClass >= 0) ? cursor.getString(i_configClass) : null);
 
-                        byte[] iconBlob = cursor.getBlob(cursor.getColumnIndex(COLUMN_WIDGET_ICON));
-                        Bitmap iconBitmap = (iconBlob != null ? BitmapFactory.decodeByteArray(iconBlob, 0, iconBlob.length) : null);
-                        Drawable iconDrawable = (iconBitmap != null ? new BitmapDrawable(context.getResources(), iconBitmap) : ContextCompat.getDrawable(context, R.drawable.ic_action_suntimes));
+                            int i_title = cursor.getColumnIndex(COLUMN_WIDGET_LABEL);    // optional
+                            String title = ((i_title >= 0) ? cursor.getString(i_title) : widgetClass);
 
-                        items.add(new WidgetListItem(packageName, widgetClass, appWidgetID, iconDrawable, title, summary, configClass));
+                            int i_summary = cursor.getColumnIndex(COLUMN_WIDGET_SUMMARY);    // optional
+                            String summary = ((i_summary >= 0) ? cursor.getString(i_summary) : packageName);
+
+                            Drawable iconDrawable;
+                            int i_icon = cursor.getColumnIndex(COLUMN_WIDGET_ICON);    // optional
+                            if (i_icon >= 0) {
+                                byte[] iconBlob = cursor.getBlob(i_icon);
+                                Bitmap iconBitmap = (iconBlob != null ? BitmapFactory.decodeByteArray(iconBlob, 0, iconBlob.length) : null);
+                                iconDrawable = (iconBitmap != null ? new BitmapDrawable(context.getResources(), iconBitmap) : ContextCompat.getDrawable(context, R.drawable.ic_action_suntimes));
+                            } else {
+                                iconDrawable = ContextCompat.getDrawable(context, R.drawable.ic_action_suntimes);
+                            }
+
+                            items.add(new WidgetListItem(packageName, widgetClass, appWidgetID, iconDrawable, title, summary, configClass));
+
+                        } catch (IllegalArgumentException e) {
+                            Log.e("WidgetListActivity", "Missing column! skipping this entry.. " + e);
+                        }
                         cursor.moveToNext();
                     }
                     cursor.close();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -83,6 +83,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
 
     private ActionBar actionBar;
     private ListView widgetList;
+    private WidgetListAdapter widgetListAdapter;
     private static final SuntimesUtils utils = new SuntimesUtils();
 
     public SuntimesWidgetListActivity()
@@ -111,7 +112,6 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
         setResult(RESULT_CANCELED);
         setContentView(R.layout.layout_activity_widgetlist);
         initViews(this);
-        updateWidgetAlarms(this);
     }
 
     /**
@@ -122,6 +122,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
     {
         super.onStart();
         updateViews(this);
+        updateWidgetAlarms(this);
     }
 
     /**
@@ -252,7 +253,8 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
      */
     protected void updateViews(@NonNull Context context)
     {
-        widgetList.setAdapter(WidgetListAdapter.createWidgetListAdapter(context));
+        widgetListAdapter = WidgetListAdapter.createWidgetListAdapter(context);
+        widgetList.setAdapter(widgetListAdapter);
     }
 
     /**
@@ -323,11 +325,17 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
      * updateWidgetAlarms
      * @param context context
      */
-    public static void updateWidgetAlarms(Context context)
+    protected void updateWidgetAlarms(Context context)
     {
-        Intent updateIntent = new Intent();
-        updateIntent.setAction(SuntimesWidget0.SUNTIMES_ALARM_UPDATE);
-        context.sendBroadcast(updateIntent);
+        if (widgetListAdapter != null)
+        {
+            for (ComponentName widgetClass : widgetListAdapter.getAllWidgetClasses())
+            {
+                Intent updateIntent = new Intent(SuntimesWidget0.SUNTIMES_ALARM_UPDATE);
+                updateIntent.setComponent(widgetClass);
+                context.sendBroadcast(updateIntent);
+            }
+        }
     }
 
     /**
@@ -394,12 +402,25 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
     @SuppressWarnings("Convert2Diamond")
     public static class WidgetListAdapter extends ArrayAdapter<WidgetListItem>
     {
-        public static String[] ALL_WIDGETS = new String[]{
+        public static String[] ALL_WIDGETS = new String[] {
                 SuntimesWidget0.class.getName(), SuntimesWidget0_2x1.class.getName(), SuntimesWidget1.class.getName(), SolsticeWidget0.class.getName(),
                 MoonWidget0.class.getName(), MoonWidget0_2x1.class.getName(), MoonWidget0_3x1.class.getName(), MoonWidget0_3x2.class.getName(),
                 SuntimesWidget2.class.getName(), SuntimesWidget2_3x1.class.getName(), SuntimesWidget2_3x2.class.getName(), SuntimesWidget2_3x3.class.getName(),
                 ClockWidget0.class.getName(), ClockWidget0_3x1.class.getName()
         };
+
+        public ComponentName[] getAllWidgetClasses()
+        {
+            ArrayList<ComponentName> components = new ArrayList<>();
+            for (WidgetListItem widget : widgets)
+            {
+                ComponentName component = new ComponentName(widget.packageName, widget.widgetClass);
+                if (!components.contains(component)) {
+                    components.add(component);
+                }
+            }
+            return components.toArray(new ComponentName[0]);
+        }
 
         private Context context;
         private ArrayList<WidgetListItem> widgets;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -20,6 +20,7 @@ package com.forrestguice.suntimeswidget;
 
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProviderInfo;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -301,14 +302,20 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
      */
     protected void reconfigureWidget(WidgetListItem widgetItem)
     {
-        Log.d("DEBUG", "reconfigureWidget: " + widgetItem.packageName + " :: " + widgetItem.configClass);
         Intent configIntent = new Intent();
-        configIntent.setComponent(new ComponentName(widgetItem.packageName, widgetItem.getConfigClass()));
-        configIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetItem.getWidgetId());
+        configIntent.setComponent(new ComponentName(widgetItem.packageName, widgetItem.configClass));
+        configIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetItem.appWidgetId);
         configIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         configIntent.putExtra(EXTRA_RECONFIGURE, true);
-        startActivity(configIntent);
-        overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);
+
+        try {
+            Log.i(getClass().getSimpleName(), "reconfigureWidget: " + widgetItem.packageName + " :: " + widgetItem.configClass);
+            startActivity(configIntent);
+            overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);
+
+        } catch (ActivityNotFoundException | SecurityException e) {
+            Log.e(getClass().getSimpleName(), "reconfigureWidget: " + widgetItem.packageName + " :: " + widgetItem.configClass + " :: " + e);
+        }
     }
 
     /**

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -30,10 +30,15 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -326,11 +331,11 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
         protected final String widgetClass;
         protected final String configClass;
         protected final int appWidgetId;
-        protected final int icon;
+        protected final Drawable icon;
         protected final String title;
         protected final String summary;
 
-        public WidgetListItem( String packageName, String widgetClass, int appWidgetId, int icon, String title, String summary, String configClass )
+        public WidgetListItem( String packageName, String widgetClass, int appWidgetId, Drawable icon, String title, String summary, String configClass )
         {
             this.packageName = packageName;
             this.widgetClass = widgetClass;
@@ -355,8 +360,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             return configClass;
         }
 
-        public int getIcon()
-        {
+        public Drawable getIcon() {
             return icon;
         }
 
@@ -424,7 +428,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             WidgetListItem item = widgets.get(position);
 
             ImageView icon = (ImageView) view.findViewById(android.R.id.icon1);
-            icon.setImageResource(item.getIcon());
+            icon.setImageDrawable(item.getIcon());
 
             TextView text = (TextView) view.findViewById(android.R.id.text1);
             text.setText(item.getTitle());
@@ -481,7 +485,7 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
                 String title = context.getString(R.string.configLabel_widgetList_itemTitle, widgetTitle);
                 String source = ((data == null || data.calculatorMode() == null) ? "def" : data.calculatorMode().getName());
                 String summary = context.getString(R.string.configLabel_widgetList_itemSummaryPattern, widgetType, source);
-                items.add(new WidgetListItem(packageName, widgetClass, id, widgetIcon, title, summary, configClass));
+                items.add(new WidgetListItem(packageName, widgetClass, id, ContextCompat.getDrawable(context, widgetIcon), title, summary, configClass));
             }
             return items;
         }
@@ -510,9 +514,12 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
 
                         String title = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_LABEL));
                         String summary = cursor.getString(cursor.getColumnIndex(COLUMN_WIDGET_SUMMARY));
-                        int icon = R.drawable.ic_action_suntimes;
-                        items.add(new WidgetListItem(packageName, widgetClass, appWidgetID, icon, title, summary, configClass));
 
+                        byte[] iconBlob = cursor.getBlob(cursor.getColumnIndex(COLUMN_WIDGET_ICON));
+                        Bitmap iconBitmap = (iconBlob != null ? BitmapFactory.decodeByteArray(iconBlob, 0, iconBlob.length) : null);
+                        Drawable iconDrawable = (iconBitmap != null ? new BitmapDrawable(context.getResources(), iconBitmap) : ContextCompat.getDrawable(context, R.drawable.ic_action_suntimes));
+
+                        items.add(new WidgetListItem(packageName, widgetClass, appWidgetID, iconDrawable, title, summary, configClass));
                         cursor.moveToNext();
                     }
                     cursor.close();
@@ -642,11 +649,12 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
     public static final String COLUMN_WIDGET_CONFIGCLASS = "configclass";
     public static final String COLUMN_WIDGET_LABEL = "label";
     public static final String COLUMN_WIDGET_SUMMARY = "summary";
+    public static final String COLUMN_WIDGET_ICON = "icon";
 
     public static final String QUERY_WIDGET = "widgets";
     public static final String[] QUERY_WIDGET_PROJECTION = new String[] {
             COLUMN_WIDGET_APPWIDGETID, COLUMN_WIDGET_CLASS, COLUMN_WIDGET_CONFIGCLASS, COLUMN_WIDGET_PACKAGENAME,
-            COLUMN_WIDGET_LABEL, COLUMN_WIDGET_SUMMARY
+            COLUMN_WIDGET_LABEL, COLUMN_WIDGET_SUMMARY, COLUMN_WIDGET_ICON
     };
 
     public static List<String> queryWidgetInfoProviders(Context context)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesWidgetListActivity.java
@@ -529,15 +529,9 @@ public class SuntimesWidgetListActivity extends AppCompatActivity
             for (String widgetClass : ALL_WIDGETS) {
                 items.addAll(createWidgetListItems(context, widgetManager, packageName, widgetClass));
             }
-
-            items.addAll(createWidgetListItems(context, widgetManager, packageName, "com.forrestguice.suntimes.naturalhour.ui.widget.NaturalHourWidget_3x2"));
-            items.addAll(createWidgetListItems(context, widgetManager, packageName, "com.forrestguice.suntimes.naturalhour.ui.widget.NaturalHourWidget_4x3"));
-            items.addAll(createWidgetListItems(context, widgetManager, packageName, "com.forrestguice.suntimes.naturalhour.ui.widget.NaturalHourWidget_5x3"));
-
             for (String uri : queryWidgetInfoProviders(context)) {
                 items.addAll(createWidgetListItems(context, uri));
             }
-
             return new WidgetListAdapter(context, items);
         }
 


### PR DESCRIPTION
* enhances the WidgetListActivity to show add-on widgets (and allow reconfigure).
* replaces implicit update intent with a series of explicit intents (one for each widget receiver).
* [permission] adds `uses "suntimes.permission.READ_CALCULATOR"` to main app (previously only declared by main app and used by addons); needed to secure addon contentproviders