### PR TITLE
release 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.13.6 (2020-12-31)
+* adds support for sidereal time (GMST, LMST) (#463).
+* adds "alarm list" button to the alarm dialog (#455); shortcut to Suntimes Alarms.
+* adds "SHOW_CARD" action to main activity; allows other apps to scroll to a given date.
+* fixes widget click action so that it also triggers an update (#459).
+* misc time zone dialog improvements.
+
 ### v0.13.5 (2020-12-04)
 * adds translation to Russian (ru) (contributed by Ruslan Chintsov) (#458).
 * updates translation to Brazilian Portuguese (pt-br) (#453 by efraletti).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 69
-        versionName "0.13.5"
+        versionCode 70
+        versionName "0.13.6"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/70.txt
+++ b/fastlane/metadata/android/en-US/changelogs/70.txt
@@ -1,0 +1,1 @@
+- adds support for sidereal time (GMST, LMST).


### PR DESCRIPTION
* adds support for sidereal time (GMST, LMST) (closes #463).
* adds "alarm list" button to the alarm dialog (closes #455); shortcut to Suntimes Alarms.
* adds "SHOW_CARD" action to main activity; allows other apps to scroll to a given date.
* fixes widget click action so that it also triggers an update (fixes #459).
* misc time zone dialog improvements.