### PR TITLE
release 0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### ~
 
-### v0.13.7 (2020-01-25)
-* fixes bug "alarm vibration turning off after screen is off" (#470).
+### v0.13.7 (2021-01-26)
+* fixes bug "alarm vibration stops after screen is off" (#470).
+* fixes broken build caused by failing `colorpicker` dependency.
 * updates translation to Polish and Esperanto (eo, pl) (#468 by Verdulo).
 
 ### v0.13.6 (2020-12-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### ~
 
+### v0.13.7 (2020-01-25)
+* fixes bug "alarm vibration turning off after screen is off" (#470).
+* updates translation to Polish and Esperanto (eo, pl) (#468 by Verdulo).
+
 ### v0.13.6 (2020-12-31)
 * adds support for sidereal time (GMST, LMST) (#463).
 * adds "alarm list" button to the alarm dialog (#455); shortcut to Suntimes Alarms.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 70
-        versionName "0.13.6"
+        versionCode 71
+        versionName "0.13.7"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/71.txt
+++ b/fastlane/metadata/android/en-US/changelogs/71.txt
@@ -1,2 +1,2 @@
-- fixes bug "alarm vibration turning off after screen is off" (#470).
+- fixes bug "alarm vibration stops after screen is off" (#470).
 - updates translation to Polish and Esperanto.

--- a/fastlane/metadata/android/en-US/changelogs/71.txt
+++ b/fastlane/metadata/android/en-US/changelogs/71.txt
@@ -1,0 +1,2 @@
+- fixes bug "alarm vibration turning off after screen is off" (#470).
+- updates translation to Polish and Esperanto.


### PR DESCRIPTION
* fixes bug "alarm vibration stops after screen is off" (closes #470).
* fixes broken build caused by failing `colorpicker` dependency.
* updates translation to Polish and Esperanto (eo, pl) (#468 by Verdulo).