### PR TITLE
release 0.13.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.13.13 (2021-09-08)
+### v0.13.13 (2021-09-09)
 * fixes bug "1x1 moon widget uses imperial units while the app metric" (#506).
 
 ### v0.13.12 (2021-06-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### ~
 
+### v0.13.13 (2021-09-08)
+* fixes bug "1x1 moon widget uses imperial units while the app metric" (#506).
+
 ### v0.13.12 (2021-06-20)
 * updates translation to German (de) (#503 by wolkenschieber).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ A calendar provider add-on for Suntimes.<br/><br />
 
 <a href="https://github.com/forrestguice/SolunarPeriods/"><img align="left" src="https://forrestguice.github.io/SuntimesWidget/assets/images/ic_solunar.png" height="64" /></a> <a href="https://github.com/forrestguice/SolunarPeriods/">Solunar Periods</a> <br />
 A hunting and fishing add-on for Suntimes.<br/><br />
+
+<a href="https://github.com/forrestguice/NaturalHour/"><img align="left" src="https://forrestguice.github.io/SuntimesWidget/assets/images/ic_naturalhour.png" height="64" /></a> <a href="https://github.com/forrestguice/NaturalHour/">Natural Hour</a> <br />
+A 24-hour clock & roman timekeeping add-on for Suntimes.<br/><br />
     
 The app:
 * displays the current time (system time zone, custom time zone, or solar time) 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 76
-        versionName "0.13.12"
+        versionCode 77
+        versionName "0.13.13"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/77.txt
+++ b/fastlane/metadata/android/en-US/changelogs/77.txt
@@ -1,0 +1,1 @@
+- fixes a bug where the moon widgets display distances using the wrong units (#506).

--- a/fastlane/metadata/android/en-US/changelogs/77.txt
+++ b/fastlane/metadata/android/en-US/changelogs/77.txt
@@ -1,1 +1,1 @@
-- fixes a bug where the moon widgets display distances using the wrong units (#506).
+- fixes bug where moon widgets show distances with the wrong units (#506).


### PR DESCRIPTION
* fixes bug "1x1 moon widget uses imperial units while the app metric" (closes #506).