### PR TITLE
release 0.13.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### ~
 
+### v0.13.17 (2022-01-02)
+* adds translation to Simplified Chinese (zh_CN) (contributed by James Liu) (#527).
+* updates translation to Traditional Chinese (zh_TW) (#527).
+* fixes alarm notifications to include the 'offset' text (more descriptive); e.g. "5m before sunset" vs "sunset" (#522).
+* fixes crash when loading AlarmCreateDialog with invalid settings (handle unknown event values).
+
 ### v0.13.16 (2021-11-29)
 * adds translation to Czech (cs) (contributed by utaxiu) (#520).
 * fixes bug where CalculatorProvider fails to apply altitude refinements. 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ When reporting a bug **please be detailed as possible**. What did you expect the
 
 ## Legal Stuff
 
-Copyright &#169; 2014-2021 Forrest Guice<br/>
+Copyright &#169; 2014-2022 Forrest Guice<br/>
 
 The source code is available under [GPLv3](LICENSE) (https://github.com/forrestguice/SuntimesWidget).
 > This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the [GNU General Public License](LICENSE) for more details.
@@ -172,11 +172,12 @@ Catalan and Spanish translations by <u><a href="https://github.com/Raulvo">Raulv
 Basque translation by <u>beriain</u>.<br/>
 Norwegian translation by <u>FTno</u>.<br/>
 Italian translation by <u>Matteo Caoduro</u> and <u>GiovaGa</u>.<br/>
-Traditional Chinese translation by <u><a href=https://github.com/pggdt>ft42</a></u>.<br />
+Traditional Chinese translation by <u><a href=https://github.com/pggdt>ft42</a></u>, and <u><a href=https://github.com/jamesliu96>James Liu</a></u>.<br />
 Brazilian Portuguese translation by <u><a href=https://github.com/netosilva15>NetoSilva</a></u>, <u>Nelson A. de Oliveira</u>, and <u>Enrico S. B. Fraletti</u>.<br />
 Russian translation by <u><a href=https://github.com/rchintsov>Ruslan Chintsov</a></u>.<br />
 Dutch translation by <u><a href=https://github.com/joppla>Joppla</a></u>.<br />
 Czech translation by <u><a href=https://github.com/utaxiu>utaxiu</a></u>.<br />
+Simplified Chinese translation by <u><a href=https://github.com/jamesliu96>James Liu</a></u>.<br />
 
 [Contributions to the project](CONTRIBUTING.md) are welcome.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 80
-        versionName "0.13.16"
+        versionCode 81
+        versionName "0.13.17"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/81.txt
+++ b/fastlane/metadata/android/en-US/changelogs/81.txt
@@ -1,0 +1,3 @@
+- adds translation to Simplified Chinese.
+- updates translation to Traditional Chinese.
+- improves alarm notifications (more descriptive).


### PR DESCRIPTION
* adds translation to Simplified Chinese (zh_CN) (contributed by James Liu) (#527).
* updates translation to Traditional Chinese (zh_TW) (#527).
* fixes alarm notifications to include the 'offset' text (more descriptive); e.g. "5m before sunset" vs "sunset" (#522).
* fixes crash when loading AlarmCreateDialog with invalid settings (handle unknown event values).