### PR TITLE
release 0.13.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### ~
 
+### v0.13.19 (2022-01-24)
+* adds help for `data source` setting; adds link to online help (#223).
+* reorganizes General settings (#223, #533); `show seconds` restored to `general`; `data source` moved into `advanced`; hides `experimental`. 
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#543 by James Liu).
+* updates translation to Norwegian (nb) (#542 by FTno).
+
 ### v0.13.18 (2022-01-14)
 * changes the solstice/equinox card to always include seconds when expanded (#533).
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#531, #532 by James Liu).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 82
-        versionName "0.13.18"
+        versionCode 83
+        versionName "0.13.19"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/83.txt
+++ b/fastlane/metadata/android/en-US/changelogs/83.txt
@@ -1,0 +1,3 @@
+- adds help to general settings.
+- updates translation to Norwegian.
+- updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* adds help for `data source` setting; adds link to online help (closes #223).
* reorganizes General settings (#533); `show seconds` restored to `general`; `data source` moved into `advanced`; hides `experimental`. 
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#543 by James Liu).
* updates translation to Norwegian (nb) (#542 by FTno).