### PR TITLE
release 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.14.1 (2022-02-21)
+### v0.14.1 (2022-02-22)
 * fixes crash when using "current location" (#556).
 * fixes bug "lightmap for tomorrow card fails to display" (#557).
 * fixes bug "content-provider supplies the wrong time zone" (#554).
@@ -9,6 +9,7 @@
 * changes default 'solar time' mode to Local Mean Time.
 * minor fixes to `en` translations; e.g. `en_US` and `en_CA` display 'fall equinox'.
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#553 by James Liu).
+* updates translation to Norwegian (nb) (#561 by FTno).
 
 ### v0.14.0 (2022-02-07)
 * extends add-on functionality; adds content-providers for actions, alarms, and alarm events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### ~
 
+### v0.14.1 (2022-02-21)
+* fixes crash when using "current location" (#556).
+* fixes bug "lightmap for tomorrow card fails to display" (#557).
+* fixes bug "content-provider supplies the wrong time zone" (#554).
+* adds default world places; ~34 additional locations.    
+* adds 'online-help' link to actions help dialog (#489, #546).
+* changes default 'solar time' mode to Local Mean Time.
+* minor fixes to `en` translations; e.g. `en_US` and `en_CA` display 'fall equinox'.
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#553 by James Liu).
+
 ### v0.14.0 (2022-02-07)
 * extends add-on functionality; adds content-providers for actions, alarms, and alarm events.
 * adds support for add-on alarms; set an alarm depending on a calculation (#516); the alarm dialog displays a popup menu of add-on AlarmPickers (hidden if none).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 84
-        versionName "0.14.0"
+        versionCode 85
+        versionName "0.14.1"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/85.txt
+++ b/fastlane/metadata/android/en-US/changelogs/85.txt
@@ -1,0 +1,4 @@
+- fixes crash when using "current location" (#556).
+- fixes bug "content-provider supplies wrong time zone" (#554).
+- fixes bug "lightmap for tomorrow fails to display" (#557).
+- updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/85.txt
+++ b/fastlane/metadata/android/en-US/changelogs/85.txt
@@ -2,3 +2,4 @@
 - fixes bug "content-provider supplies wrong time zone" (#554).
 - fixes bug "lightmap for tomorrow fails to display" (#557).
 - updates translations to Simplified Chinese, and Traditional Chinese.
+- updates translation to Norwegian.


### PR DESCRIPTION
* fixes crash when using "current location" (fixes #556).
* fixes bug "lightmap for tomorrow card fails to display" (fixes #557).
* fixes bug "content-provider supplies the wrong time zone" (fixes #554).
* adds default world places; ~34 additional locations.    
* adds 'online-help' link to actions help dialog (#489, closes #546).
* changes default 'solar time' mode to Local Mean Time.
* minor fixes to `en` translations; e.g. `en_US` and `en_CA` display 'fall equinox'.
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#553 by James Liu).
* updates translation to Norwegian (nb) (#561 by FTno).