### PR TITLE
release 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * changes default 'time zone mode' back to `system`; reverts change from 7c288be (#565).
 * adds extras to SuntimesActivity intent; `ACTION_VIEW_SUN` and `ACTION_VIEW_WORLDMAP` now accept `EXTRA_SHOW_DATE`; `ACTION_ADD_ALARM` accepts `EXTRA_SOLAREVENT`.
 * updates translation to Norwegian (nb) (#568 by FTno).
+* updates translations to Polish (pl) and Esperanto (eo) (#571 by Verdulo).
 
 ### v0.14.1 (2022-02-22)
 * fixes crash when using "current location" (#556).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### ~
 
+### v0.14.2 (2022-03-14)
+* fixes crash when using 'sun position' app shortcut (#567).
+* fixes bug where "search places doesn't work" (#566).
+* fixes bug where '1x1 moon widget' illumination is always displayed (fails to be hidden) (#563).
+* changes default 'time zone mode' back to `system`; reverts change from 7c288be (#565).
+* adds extras to SuntimesActivity intent; `ACTION_VIEW_SUN` and `ACTION_VIEW_WORLDMAP` now accept `EXTRA_SHOW_DATE`; `ACTION_ADD_ALARM` accepts `EXTRA_SOLAREVENT`.
+* updates translation to Norwegian (nb) (#568 by FTno).
+
 ### v0.14.1 (2022-02-22)
 * fixes crash when using "current location" (#556).
 * fixes bug "lightmap for tomorrow card fails to display" (#557).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 85
-        versionName "0.14.1"
+        versionCode 86
+        versionName "0.14.2"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/86.txt
+++ b/fastlane/metadata/android/en-US/changelogs/86.txt
@@ -1,0 +1,3 @@
+- fixes crash when using 'sun position' app shortcut (#567).
+- fixes bug where "search places doesn't work" (#566).
+- updates translation to Norwegian.

--- a/fastlane/metadata/android/en-US/changelogs/86.txt
+++ b/fastlane/metadata/android/en-US/changelogs/86.txt
@@ -1,3 +1,4 @@
 - fixes crash when using 'sun position' app shortcut (#567).
 - fixes bug where "search places doesn't work" (#566).
 - updates translation to Norwegian.
+- updates translation to Polish and Esperanto.


### PR DESCRIPTION
* fixes crash when using 'sun position' app shortcut (closes #567).
* fixes bug where "search places doesn't work" (closes #566).
* fixes bug where '1x1 moon widget' illumination is always displayed (fails to be hidden) (closes #563).
* changes default 'time zone mode' back to `system`; reverts change from 7c288be (closes #565).
* adds extras to SuntimesActivity intent; `ACTION_VIEW_SUN` and `ACTION_VIEW_WORLDMAP` now accept `EXTRA_SHOW_DATE`; `ACTION_ADD_ALARM` accepts `EXTRA_SOLAREVENT`.
* updates translation to Norwegian (nb) (#568 by FTno).
* updates translations to Polish (pl) and Esperanto (eo) (#571 by Verdulo).