### PR TITLE
release 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### ~
 
+### v0.14.3 (2022-04-11)
+* adds click to solar noon field; opens the lightmap dialog (#562).
+* changes click on sunrise/sunset headers; opens the lightmap dialog if configured to show azimuth (#562).
+* fixes lunar noon field; omit on days it doesn't occur (#572).
+* fixes bug "solstice dialog 'view date' menu doesn't work" (#577).
+* fixes bug where the AlarmNotifications service fails to stop (battery use in background) (#575).
+* fixes ANR when showing alarm dialog (#576); misc changes to ringtone management.
+* fixes app crash when using 'fallback to last location'.
+* fixes bug where changes made in the PlacesActivity aren't displayed by the location spinner.
+* changes action prefix to "suntimes.action"; remaps legacy actions.
+* misc layout changes (enlarged click areas); misc cleanup/refactoring.
+
 ### v0.14.2 (2022-03-14)
 * fixes crash when using 'sun position' app shortcut (#567).
 * fixes bug where "search places doesn't work" (#566).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 86
-        versionName "0.14.2"
+        versionCode 87
+        versionName "0.14.3"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/87.txt
+++ b/fastlane/metadata/android/en-US/changelogs/87.txt
@@ -1,0 +1,5 @@
+- adds click to solar noon field (#562).
+- fixes bug in lunar noon field (#572).
+- fixes bug that causes background battery use (#575).
+- fixes bug "solstice dialog 'view date' menu doesn't work" (#577).
+- fixes crash when using 'fallback to last location'.


### PR DESCRIPTION
* adds click to solar noon field; opens the lightmap dialog (closes #562).
* changes click on sunrise/sunset headers; opens the lightmap dialog if configured to show azimuth (closes #562).
* fixes lunar noon field; omit on days it doesn't occur (#572).
* fixes bug "solstice dialog 'view date' menu doesn't work" (closes #577).
* fixes bug where the AlarmNotifications service fails to stop (battery use in background) (closes #575).
* fixes ANR when showing alarm dialog (closes #576); misc changes to ringtone management.
* fixes app crash when using 'fallback to last location'.
* fixes bug where changes made in the PlacesActivity aren't displayed by the location spinner.
* changes action prefix to "suntimes.action"; remaps legacy actions.
* misc layout changes (enlarged click areas); misc cleanup/refactoring.