### PR TITLE
release 0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 ### ~
 
-### v0.14.4 (2022-05-02)
-* adds import/export to SuntimesAlarms (#588); save and load alarms/notifications as JSON.
-* adds support for standard AlarmClock intents to SuntimesAlarms; `android.intent.action.SHOW_ALARMS`, `android.intent.action.DISMISS_ALARM` (`EXTRA_ALARM_SEARCH_MODE`), and `android.intent.action.SNOOZE_ALARM` (`android.intent.extra.alarm.SNOOZE_DURATION`).
-* extends the widget action dialog to suggest package and class names from installed apps (#546).
+### v0.14.4 (2022-05-03)
+* adds import/export to SuntimesAlarms (#588); save and load alarms as JSON.
+* adds widget layouts (3x1 sun position); show the lightmap graph with reduced height (#589).
+* extends map widgets to use the dialog configuration; shared options for center/background/tint, sunlight/moonlight, location, latitudes, and graticule (#493).
+* extends the widget action dialog to suggest package/class names (#546).
 * fixes bug where widget actions that use an explicit intent fail to launch (#546).
-* fixes bug where the sun position and map animations runs in the background (#582).
-* fixes bug in sun position widget where the theme colors aren't applied; fixes default lightmap colors (#589).
+* fixes bug where widget action extras are not correctly applied (#546); ints omitted, longs applied as String.
+* fixes bug where the sun position dialog and map dialog animations run in the background (#582).
+* fixes bug in sun position widgets where the theme colors aren't applied; fixes default colors (#589); adds graph pointFill and pointStroke colors.
 * fixes bug where single-select menu items are displayed as checkboxes instead of radio buttons (#590).
+* fixes bug where the widget theme spinner fails to show the background preview.
 * fixes issue with 'Advanced' settings discoverability (#581).
+* fixes SuntimesAlarms intent-filter to support standard AlarmClock intents; `android.intent.action.SHOW_ALARMS`, `android.intent.action.DISMISS_ALARM` (`EXTRA_ALARM_SEARCH_MODE`), and `android.intent.action.SNOOZE_ALARM` (`android.intent.extra.alarm.SNOOZE_DURATION`); adds 'snooze alarm' and 'dismiss alarm' default actions.
 * updates translation to Polish and Esperanto (eo, pl) (#585 by Verdulo).
 * updates translation to Brazilian Portuguese (pt-br) (#587 by naoliv).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 * adds support for standard AlarmClock intents to SuntimesAlarms; `android.intent.action.SHOW_ALARMS`, `android.intent.action.DISMISS_ALARM` (`EXTRA_ALARM_SEARCH_MODE`), and `android.intent.action.SNOOZE_ALARM` (`android.intent.extra.alarm.SNOOZE_DURATION`).
 * extends the widget action dialog to suggest package and class names from installed apps (#546).
 * fixes bug where widget actions that use an explicit intent fail to launch (#546).
+* fixes bug where the sun position and map animations runs in the background (#582).
 * fixes bug in sun position widget where the theme colors aren't applied; fixes default lightmap colors (#589).
 * fixes bug where single-select menu items are displayed as checkboxes instead of radio buttons (#590).
+* fixes issue with 'Advanced' settings discoverability (#581).
 * updates translation to Polish and Esperanto (eo, pl) (#585 by Verdulo).
 * updates translation to Brazilian Portuguese (pt-br) (#587 by naoliv).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### ~
 
+### v0.14.4 (2022-05-02)
+* adds import/export to SuntimesAlarms (#588); save and load alarms/notifications as JSON.
+* adds support for standard AlarmClock intents to SuntimesAlarms; `android.intent.action.SHOW_ALARMS`, `android.intent.action.DISMISS_ALARM` (`EXTRA_ALARM_SEARCH_MODE`), and `android.intent.action.SNOOZE_ALARM` (`android.intent.extra.alarm.SNOOZE_DURATION`).
+* extends the widget action dialog to suggest package and class names from installed apps (#546).
+* fixes bug where widget actions that use an explicit intent fail to launch (#546).
+* fixes bug in sun position widget where the theme colors aren't applied; fixes default lightmap colors (#589).
+* fixes bug where single-select menu items are displayed as checkboxes instead of radio buttons (#590).
+* updates translation to Polish and Esperanto (eo, pl) (#585 by Verdulo).
+* updates translation to Brazilian Portuguese (pt-br) (#587 by naoliv).
+
 ### v0.14.3 (2022-04-11)
 * adds click to solar noon field; opens the lightmap dialog (#562).
 * changes click on sunrise/sunset headers; opens the lightmap dialog if configured to show azimuth (#562).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 87
-        versionName "0.14.3"
+        versionCode 88
+        versionName "0.14.4"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/88.txt
+++ b/fastlane/metadata/android/en-US/changelogs/88.txt
@@ -1,7 +1,8 @@
 - adds import/export to SuntimesAlarms (#588).
-- extends the widget action editor to suggest package/class names (#546).
+- extends the position widget (reduced height), and map widgets (configuration).
+- extends the action editor to suggest package/class names (#546).
 - fixes bug where widget actions fail to launch (#546).
-- fixes bug where animations runs in the background (#582).
 - fixes bug where widget theme colors aren't applied (#589).
+- fixes bug where animations run in the background (#582).
 - updates translation to Polish and Esperanto.
 - updates translation to Brazilian Portuguese.

--- a/fastlane/metadata/android/en-US/changelogs/88.txt
+++ b/fastlane/metadata/android/en-US/changelogs/88.txt
@@ -1,6 +1,7 @@
 - adds import/export to SuntimesAlarms (#588).
 - extends the widget action editor to suggest package/class names (#546).
 - fixes bug where widget actions fail to launch (#546).
+- fixes bug where animations runs in the background (#582).
 - fixes bug where widget theme colors aren't applied (#589).
 - updates translation to Polish and Esperanto.
 - updates translation to Brazilian Portuguese.

--- a/fastlane/metadata/android/en-US/changelogs/88.txt
+++ b/fastlane/metadata/android/en-US/changelogs/88.txt
@@ -1,0 +1,6 @@
+- adds import/export to SuntimesAlarms (#588).
+- extends the widget action editor to suggest package/class names (#546).
+- fixes bug where widget actions fail to launch (#546).
+- fixes bug where widget theme colors aren't applied (#589).
+- updates translation to Polish and Esperanto.
+- updates translation to Brazilian Portuguese.


### PR DESCRIPTION
* adds import/export to SuntimesAlarms (closes #588); save and load alarms/notifications as JSON.
* adds widget layouts (3x1 sun position); show the lightmap graph with reduced height (#589).
* extends map widgets to use the dialog configuration; shared options for center/background/tint, sunlight/moonlight, location, latitudes, and graticule (#493).
* extends the widget action dialog to suggest package and class names from installed apps (#546).
* fixes bug where widget actions that use an explicit intent fail to launch (closes #546).
* fixes bug where widget action extras are not correctly applied (#546); ints omitted, longs applied as String.
* fixes bug where the sun position and map animations runs in the background (closes #582).
* fixes bug in sun position widget where the theme colors aren't applied; fixes default lightmap colors (#589); adds graph pointFill and pointStroke colors.
* fixes bug where single-select menu items are displayed as checkboxes instead of radio buttons (closes #590).
* fixes bug where the widget theme spinner fails to show the background preview.
* fixes issue with 'Advanced' settings discoverability (closes #581).
* fixes SuntimesAlarms intent-filter to support standard AlarmClock intents; `android.intent.action.SHOW_ALARMS`, `android.intent.action.DISMISS_ALARM` (`EXTRA_ALARM_SEARCH_MODE`), and `android.intent.action.SNOOZE_ALARM` (`android.intent.extra.alarm.SNOOZE_DURATION`); adds 'snooze alarm' and 'dismiss alarm' default actions.
* updates translation to Polish and Esperanto (eo, pl) (#585 by Verdulo).
* updates translation to Brazilian Portuguese (pt-br) (#587 by naoliv).