### PR TITLE
alarm export

### DIFF
--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapterTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapterTest.java
@@ -344,13 +344,13 @@ public class AlarmDatabaseAdapterTest
         Location location0 = new Location(TESTLOC_0_LABEL, TESTLOC_0_LAT, TESTLOC_0_LON);
         Location location1 = new Location(TESTLOC_1_LABEL, TESTLOC_1_LAT, TESTLOC_1_LON, TESTLOC_1_ALT);
 
-        String[] events = new String[] {"SUNRISE", "SUNSET", "CIVILRISE", null, "MOONRISE", "MOONSET"};
+        String[] events = new String[] {"SUNRISE", "SUNSET", "MORNING_CIVIL", null, "MOONRISE", "MOONSET"};
         boolean[] enabled = new boolean[] {true, false, false, true, true, false};
         boolean[] vibrate = new boolean[] {false, true, true, true, false, false};
         boolean[] repeating = new boolean[] {false, false, true, true, false, false};
         Location[] locations = new Location[] {location0, location0, location1, location1, location0, null};
         String[] timezones = new String[] {TESTTZID_0, TESTTZID_1, TESTTZID_2, TESTTZID_1, TESTTZID_2, null};
-        String[] repeatDays = new String[] {"", "0,1", "0,1,2,3", "1,2", null, "0,1,2,3,4,5,6"};
+        String[] repeatDays = new String[] {"", "1", "0,1,2,3", "1,2", null, "1,2,3,4,5,6"};   // 0 is invalid value
         AlarmClockItem.AlarmType[] types = new AlarmClockItem.AlarmType[] { ALARM, ALARM, NOTIFICATION, null, ALARM, ALARM };
         int[] hours = new int[] {6, 18, 5, 19, 12, 6};
         int[] minutes = new int[] {30, 10, 0, 1, 59, 6};

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapterTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/AlarmDatabaseAdapterTest.java
@@ -268,6 +268,9 @@ public class AlarmDatabaseAdapterTest
         db.open();
         for (AlarmClockItem alarm : alarms)
         {
+            if (alarm.type == null) {
+                continue;
+            }
             long id = db.addAlarm(alarm.asContentValues(false));
             assertTrue("ID should be >= 0 (was " + id + ")", id != -1);
             count++;

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettingsTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettingsTest.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.fail;
 
@@ -90,6 +91,21 @@ public class AlarmSettingsTest extends SuntimesActivityTestBase
             if (set.contains(key)) {
                 fail("AlarmSettings key is not unique! " + key);
             } else set.add(key);
+        }
+    }
+
+    @Test
+    public void test_getRingtoneName()
+    {
+        Uri[] test_uri = new Uri[] {
+                Uri.parse("content://dne"), Uri.parse("invalid"), Uri.parse(""), null,
+                RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_ALARM),
+                RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_NOTIFICATION)
+        };
+        for (Uri uri : test_uri)
+        {
+            String name = AlarmSettings.getRingtoneName(context, uri);
+            assertNotNull(name);
         }
     }
 

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
@@ -20,11 +20,14 @@ package com.forrestguice.suntimeswidget.alarmclock;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.RenamingDelegatingContext;
 
+import com.forrestguice.suntimeswidget.ExportTask;
 import com.forrestguice.suntimeswidget.SuntimesActivityTestBase;
 
 import org.json.JSONObject;
@@ -38,9 +41,12 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import static android.test.MoreAsserts.assertNotEqual;
 import static com.forrestguice.suntimeswidget.alarmclock.AlarmClockItem.AlarmType.ALARM;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
 @LargeTest
@@ -52,6 +58,27 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
     @Before
     public void setup() {
         mockContext = new RenamingDelegatingContext(InstrumentationRegistry.getTargetContext(), "test_");
+    }
+
+    @Test
+    public void test_getOpenFileIntent()
+    {
+        String mimeType0 = "text/*";
+        Intent intent0 = ExportTask.getOpenFileIntent(mimeType0);
+        int flags0 = intent0.getFlags();
+
+        if (Build.VERSION.SDK_INT >= 19)
+        {
+            assertEquals(Intent.ACTION_OPEN_DOCUMENT, intent0.getAction());
+            assertTrue("has category: " + Intent.CATEGORY_OPENABLE, intent0.hasCategory(Intent.CATEGORY_OPENABLE));
+            assertTrue("has extra: " + Intent.EXTRA_ALLOW_MULTIPLE, intent0.hasExtra(Intent.EXTRA_ALLOW_MULTIPLE));
+            assertFalse(intent0.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, true));
+            assertNotEqual("failed to set FLAG_GRANT_PERSISTABLE_URI_PERMISSION", 0, ((flags0 & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)));
+        } else {
+            assertEquals(Intent.ACTION_GET_CONTENT, intent0.getAction());
+        }
+        assertEquals("failed to set mimeType", mimeType0, intent0.getType());
+        assertNotEqual("failed to set FLAG_GRANT_READ_URI_PERMISSION", 0, ((flags0 & Intent.FLAG_GRANT_READ_URI_PERMISSION)));
     }
 
     @Test

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
@@ -46,6 +46,7 @@ import static com.forrestguice.suntimeswidget.alarmclock.AlarmClockItem.AlarmTyp
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
@@ -100,6 +101,13 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
             assertNotEqual("failed to set FLAG_GRANT_PERSISTABLE_URI_PERMISSION", 0, ((flags0 & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)));
             assertNotEqual("failed to set FLAG_GRANT_WRITE_URI_PERMISSION", 0, ((flags0 & Intent.FLAG_GRANT_WRITE_URI_PERMISSION)));
         }
+    }
+
+    @Test
+    public void test_getFileName()
+    {
+        String filename0 = ExportTask.getFileName(null, null);
+        assertNull(filename0);
     }
 
     @Test

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
@@ -70,6 +70,10 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
         }
         s.append("]");
 
+        for (AlarmClockItem item : items0) {
+            AlarmNotifications.updateAlarmTime(mockContext, item);
+        }
+
         // and back again
         InputStream in = new ByteArrayInputStream(s.toString().getBytes());
         ArrayList<AlarmClockItem> items = new ArrayList<>();
@@ -95,6 +99,9 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
         AlarmClockItem item1 = items[1];
         String json1 = AlarmClockItemImportTask.AlarmClockItemJson.toJson(item1);
 
+        AlarmNotifications.updateAlarmTime(mockContext, items[0]);
+        AlarmNotifications.updateAlarmTime(mockContext, items[1]);
+
         test_import(json0, items[0]);                                                   // valid (single obj)
         test_import("[" + json0 + "]", items[0]);                             // valid (array; single obj)
         test_import("[" + json0 + ", " + json1 + "]", items[0], items[1]);    // valid (array; unique)
@@ -109,7 +116,7 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
         test_import("[" + json0 + ", " + json1, items[0], items[1]);          // invalid (array; missing end bracket .. should read objects anyway)
         test_import(json0 + ", " + json1 + "]", items[0]);                    // invalid (array; missing start bracket .. should read first object only)
 
-        test_import(json0.substring(0, json0.length()-1), items[0]);                    // invalid (single obj; missing end-bracket)
+        test_import(json0.substring(0, json0.length()-1), null);                    // invalid (single obj; missing end-bracket)
         test_import(json0.substring(1, json0.length()-1), null);               // invalid (single obj; missing brackets)
         test_import(json0 + ", " + json1, items[0]);                          // invalid (multiple objs outside array .. should read first object only)
         test_import(json0 + json1, items[0]);                                 // invalid (multiple objs outside array, missing separator .. should read first object only)
@@ -189,7 +196,7 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
             assertEquals((oracle != null ? oracle.length : 0), items.size());
             if (oracle != null && expected) {
                 for (int i = 0; i < oracle.length; i++) {
-                    test_equals(items.get(i), oracle[i]);
+                    test_equals( oracle[i], items.get(i));
                 }
             }
             if (!expected) {   // when !expected, the following line shouldn't be reached..

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/alarmclock/ImportAlarmsTest.java
@@ -82,6 +82,27 @@ public class ImportAlarmsTest extends SuntimesActivityTestBase
     }
 
     @Test
+    public void test_getCreateFileIntent()
+    {
+        if (Build.VERSION.SDK_INT >= 19)
+        {
+            String mimeType0 = "text/*";
+            String filename0 = "testfile.txt";
+            Intent intent0 = ExportTask.getCreateFileIntent(filename0, mimeType0);
+
+            assertEquals(Intent.ACTION_CREATE_DOCUMENT, intent0.getAction());
+            assertEquals("failed to set mimeType", mimeType0, intent0.getType());
+            assertTrue("has category: " + Intent.CATEGORY_OPENABLE, intent0.hasCategory(Intent.CATEGORY_OPENABLE));
+            assertTrue("has extra: " + Intent.EXTRA_TITLE, intent0.hasExtra(Intent.EXTRA_TITLE));
+            assertEquals(filename0, intent0.getStringExtra(Intent.EXTRA_TITLE));
+
+            int flags0 = intent0.getFlags();
+            assertNotEqual("failed to set FLAG_GRANT_PERSISTABLE_URI_PERMISSION", 0, ((flags0 & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)));
+            assertNotEqual("failed to set FLAG_GRANT_WRITE_URI_PERMISSION", 0, ((flags0 & Intent.FLAG_GRANT_WRITE_URI_PERMISSION)));
+        }
+    }
+
+    @Test
     public void test_readAlarmClockItems0()
     {
         AlarmClockItem[] items0 = AlarmDatabaseAdapterTest.createTestItems();

--- a/app/src/androidTest/java/com/forrestguice/suntimeswidget/settings/AppSettingsTest.java
+++ b/app/src/androidTest/java/com/forrestguice/suntimeswidget/settings/AppSettingsTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 @SuppressWarnings({"PointlessBooleanExpression", "ConstantConditions"})
@@ -242,4 +243,24 @@ public class AppSettingsTest extends SuntimesActivityTestBase
         }
         assertTrue("default must belong to R.array.getFix_maxElapse_values", found);
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_dialogDoNotShowAgain()
+    {
+        String dialogKey1 = "testdialog1";
+        String dialogKey2 = "testdialog2";
+
+        AppSettings.setDialogDoNotShowAgain(context, dialogKey1, false);
+        AppSettings.setDialogDoNotShowAgain(context, dialogKey2, true);
+        assertFalse(AppSettings.checkDialogDoNotShowAgain(context, dialogKey1));
+        assertTrue(AppSettings.checkDialogDoNotShowAgain(context, dialogKey2));
+
+        AppSettings.setDialogDoNotShowAgain(context, dialogKey1, true);
+        AppSettings.setDialogDoNotShowAgain(context, dialogKey2, false);
+        assertTrue(AppSettings.checkDialogDoNotShowAgain(context, dialogKey1));
+        assertFalse(AppSettings.checkDialogDoNotShowAgain(context, dialogKey2));
+    }
+
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
@@ -18,6 +18,7 @@
 
 package com.forrestguice.suntimeswidget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -452,6 +453,18 @@ public abstract class ExportTask extends AsyncTask<Object, Object, ExportTask.Ex
 
         intent.setType(mimeType);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        return intent;
+    }
+
+    @TargetApi(19)
+    public static Intent getCreateFileIntent(String suggestedFileName, String mimeType)
+    {
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.putExtra(Intent.EXTRA_TITLE, suggestedFileName);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(mimeType);
+        intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         return intent;
     }
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
@@ -76,10 +76,10 @@ public abstract class ExportTask extends AsyncTask<Object, Object, ExportTask.Ex
         this.saveToCache = saveToCache;
         this.useExternalStorage = useExternalStorage;
     }
-    public ExportTask(Context context, String exportTarget, Uri exportUri)
+    public ExportTask(Context context, Uri exportUri)
     {
         this.contextRef = new WeakReference<Context>(context);
-        this.exportTarget = exportTarget;
+        this.exportTarget = null;
         this.exportUri = exportUri;
         this.saveToCache = false;
         this.useExternalStorage = false;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
@@ -19,12 +19,17 @@
 package com.forrestguice.suntimeswidget;
 
 import android.annotation.TargetApi;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Environment;
+import android.provider.OpenableColumns;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.FileProvider;
 import android.util.Log;
 
@@ -467,4 +472,22 @@ public abstract class ExportTask extends AsyncTask<Object, Object, ExportTask.Ex
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         return intent;
     }
+
+    @Nullable
+    public static String getFileName(@Nullable ContentResolver resolver, @Nullable Uri uri)
+    {
+        if (resolver != null && uri != null)
+        {
+            Cursor cursor = resolver.query(uri, null, null, null, null);
+            if (cursor != null)
+            {
+                cursor.moveToFirst();
+                String filename = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+                cursor.close();
+                return filename;
+            }
+        }
+        return null;
+    }
+
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/ExportTask.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2017-2019 Forrest Guice
+    Copyright (C) 2017-2022 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Environment;
 import android.support.v4.content.FileProvider;
 import android.util.Log;
@@ -30,7 +31,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -434,5 +434,24 @@ public abstract class ExportTask extends AsyncTask<Object, Object, ExportTask.Ex
         } catch (Exception e) {
             Log.e("ExportTask", "shareResult: Failed to share file URI! " + e);
         }
+    }
+
+    public static Intent getOpenFileIntent(String mimeType)
+    {
+        Intent intent;
+        if (Build.VERSION.SDK_INT >= 19)
+        {
+            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+
+        } else {
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
+        }
+
+        intent.setType(mimeType);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        return intent;
     }
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemExportTask.java
@@ -19,6 +19,7 @@
 package com.forrestguice.suntimeswidget.alarmclock;
 
 import android.content.Context;
+import android.net.Uri;
 
 import com.forrestguice.suntimeswidget.ExportTask;
 
@@ -42,6 +43,11 @@ public class AlarmClockItemExportTask extends ExportTask
     public AlarmClockItemExportTask(Context context, String exportTarget, boolean useExternalStorage, boolean saveToCache)
     {
         super(context, exportTarget, useExternalStorage, saveToCache);
+        initTask();
+    }
+    public AlarmClockItemExportTask(Context context, Uri exportUri)
+    {
+        super(context, exportUri);
         initTask();
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemExportTask.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 public class AlarmClockItemExportTask extends ExportTask
 {
     public static final String FILEEXT = ".json";
-    public static final String MIMETYPE = "application/octet-stream";
+    public static final String MIMETYPE = "application/json";
 
     public AlarmClockItemExportTask(Context context, String exportTarget)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemExportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemExportTask.java
@@ -32,8 +32,8 @@ import java.io.IOException;
  */
 public class AlarmClockItemExportTask extends ExportTask
 {
-    public static final String FILEEXT = ".json";
-    public static final String MIMETYPE = "application/json";
+    public static final String FILEEXT = ".txt";
+    public static final String MIMETYPE = "text/plain";
 
     public AlarmClockItemExportTask(Context context, String exportTarget)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemImportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemImportTask.java
@@ -227,7 +227,11 @@ public class AlarmClockItemImportTask extends AsyncTask<Uri, AlarmClockItem, Ala
         {
             switch (reader.peek()) {
                 case BEGIN_ARRAY: readAlarmClockItemArray(context, reader, items); break;
-                case BEGIN_OBJECT: items.add(readAlarmClockItem(context, reader)); break;
+                case BEGIN_OBJECT: AlarmClockItem item = readAlarmClockItem(context, reader);
+                    if (item != null) {
+                        items.add(item);
+                    }
+                    break;
                 default: reader.skipValue(); break;
             }
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemImportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemImportTask.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -112,6 +111,13 @@ public class AlarmClockItemImportTask extends AsyncTask<Uri, AlarmClockItem, Ala
                 items = null;
                 error = e;
             }
+        }
+
+        for (AlarmClockItem item : items)
+        {
+            // TODO: check existing ringtoneURI first .. is it playable? then no need to overwrite with the default
+            item.ringtoneURI = AlarmSettings.VALUE_RINGTONE_DEFAULT;
+            item.ringtoneName = AlarmSettings.VALUE_RINGTONE_DEFAULT;
         }
 
         Log.d(getClass().getSimpleName(), "doInBackground: waiting");

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemImportTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmClockItemImportTask.java
@@ -115,9 +115,12 @@ public class AlarmClockItemImportTask extends AsyncTask<Uri, AlarmClockItem, Ala
 
         for (AlarmClockItem item : items)
         {
-            // TODO: check existing ringtoneURI first .. is it playable? then no need to overwrite with the default
-            item.ringtoneURI = AlarmSettings.VALUE_RINGTONE_DEFAULT;
-            item.ringtoneName = AlarmSettings.VALUE_RINGTONE_DEFAULT;
+            if (item.ringtoneURI != null)    // don't reset null uris (silent alarms)
+            {
+                // TODO: check existing ringtoneURI first .. is it playable? then no need to overwrite with the default
+                item.ringtoneURI = AlarmSettings.VALUE_RINGTONE_DEFAULT;
+                item.ringtoneName = AlarmSettings.VALUE_RINGTONE_DEFAULT;
+            }
         }
 
         Log.d(getClass().getSimpleName(), "doInBackground: waiting");

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -224,11 +224,15 @@ public class AlarmSettings
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
+    @NonNull
     public static String getRingtoneName(Context context, Uri ringtoneUri)
     {
+        String ringtoneName = "";
         Ringtone ringtone = RingtoneManager.getRingtone(context, ringtoneUri);      // TODO: getRingtone takes up to 100ms!
-        String ringtoneName = ringtone.getTitle(context);
-        ringtone.stop();
+        if (ringtone != null) {
+            ringtoneName = ringtone.getTitle(context);
+            ringtone.stop();
+        }
         return ringtoneName;
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -600,8 +600,24 @@ public class AlarmListDialog extends DialogFragment
             Log.e("ImportAlarms", "Already busy importing/exporting! ignoring request");
 
         } else {
-            Intent intent = new Intent((Build.VERSION.SDK_INT >= 19 ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT));
+            Intent intent;
+            if (Build.VERSION.SDK_INT >= 19)
+            {
+                intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+
+            } else {
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+            }
+
+            if (Build.VERSION.SDK_INT >= 11) {
+                intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+            }
+
             intent.setType(AlarmClockItemExportTask.MIMETYPE);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             startActivityForResult(intent, REQUEST_IMPORT_URI);
         }
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -600,24 +600,7 @@ public class AlarmListDialog extends DialogFragment
             Log.e("ImportAlarms", "Already busy importing/exporting! ignoring request");
 
         } else {
-            Intent intent;
-            if (Build.VERSION.SDK_INT >= 19)
-            {
-                intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                intent.addCategory(Intent.CATEGORY_OPENABLE);
-                intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
-
-            } else {
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-            }
-
-            if (Build.VERSION.SDK_INT >= 11) {
-                intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
-            }
-
-            intent.setType(AlarmClockItemExportTask.MIMETYPE);
-            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            Intent intent = ExportTask.getOpenFileIntent(AlarmClockItemExportTask.MIMETYPE);
             startActivityForResult(intent, REQUEST_IMPORT_URI);
         }
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -99,6 +99,8 @@ public class AlarmListDialog extends DialogFragment
     public static final int REQUEST_IMPORT_URI = 100;
     public static final int REQUEST_EXPORT_URI = 200;
 
+    public static final String DIALOG_IMPORT_WARNING = "importwarning";
+
     protected View emptyView;
     protected RecyclerView list;
     protected AlarmListDialogAdapter adapter;
@@ -607,15 +609,26 @@ public class AlarmListDialog extends DialogFragment
         }
     }
 
-    protected void importAlarms(Context context, @NonNull Uri uri)
+    protected void importAlarms(final Context context, @NonNull final Uri uri)
     {
         if (importTask != null && exportTask != null) {
             Log.e("ImportAlarms", "Already busy importing/exporting! ignoring request");
 
         } else if (context != null) {
-            importTask = new AlarmClockItemImportTask(context);
-            importTask.setTaskListener(importListener);
-            importTask.execute(uri);
+            DialogInterface.OnClickListener onWarningAcknowledged = new DialogInterface.OnClickListener()
+            {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    importTask = new AlarmClockItemImportTask(context);
+                    importTask.setTaskListener(importListener);
+                    importTask.execute(uri);
+                }
+            };
+            if (!AppSettings.checkDialogDoNotShowAgain(context, DIALOG_IMPORT_WARNING)) {
+                AppSettings.buildAlertDialog(DIALOG_IMPORT_WARNING, getLayoutInflater(),
+                        R.drawable.ic_action_warning, context.getString(R.string.dialog_title_caution),
+                        context.getString(R.string.importalarms_msg_warning), onWarningAcknowledged).show();
+            } else onWarningAcknowledged.onClick(null, DialogInterface.BUTTON_POSITIVE);
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -638,7 +638,8 @@ public class AlarmListDialog extends DialogFragment
         View view = getView();
         if (context != null && view != null)
         {
-            Snackbar snackbar = Snackbar.make(view, context.getString(R.string.importalarms_toast_success, items.size() + ""), Snackbar.LENGTH_INDEFINITE);
+            String plural = context.getResources().getQuantityString(R.plurals.alarmPlural, items.size(), items.size());
+            Snackbar snackbar = Snackbar.make(view, context.getString(R.string.importalarms_toast_success, plural), Snackbar.LENGTH_INDEFINITE);
             snackbar.setAction(context.getString(R.string.configAction_undo), new View.OnClickListener() {
                 @Override
                 public void onClick(View v)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -561,30 +561,34 @@ public class AlarmListDialog extends DialogFragment
             exportTask = null;
             showProgress(false);
 
-            File file = results.getExportFile();
-            String path = ((file != null) ? file.getAbsolutePath() : results.getExportUri().toString());
-
-            if (results.getResult())
+            Context context = getActivity();
+            if (context != null)
             {
-                if (isAdded()) {
-                    String successMessage = getString(R.string.msg_export_success, path);
-                    Toast.makeText(getActivity(), successMessage, Toast.LENGTH_LONG).show();
-                    // TODO: use a snackbar instead; offer 'copy path' action
-                }
+                File file = results.getExportFile();
+                String path = ((file != null) ? file.getAbsolutePath() : ExportTask.getFileName(getContext().getContentResolver(), results.getExportUri()));
 
-                if (Build.VERSION.SDK_INT >= 19) {
-                    if (results.getExportUri() == null) {
+                if (results.getResult())
+                {
+                    if (isAdded()) {
+                        String successMessage = getString(R.string.msg_export_success, path);
+                        Toast.makeText(getActivity(), successMessage, Toast.LENGTH_LONG).show();
+                        // TODO: use a snackbar instead; offer 'copy path' action
+                    }
+
+                    if (Build.VERSION.SDK_INT >= 19) {
+                        if (results.getExportUri() == null) {
+                            ExportTask.shareResult(getActivity(), results.getExportFile(), results.getMimeType());
+                        }
+                    } else {
                         ExportTask.shareResult(getActivity(), results.getExportFile(), results.getMimeType());
                     }
-                } else {
-                    ExportTask.shareResult(getActivity(), results.getExportFile(), results.getMimeType());
+                    return;
                 }
-                return;
-            }
 
-            if (isAdded()) {
-                String failureMessage = getString(R.string.msg_export_failure, path);
-                Toast.makeText(getActivity(), failureMessage, Toast.LENGTH_LONG).show();
+                if (isAdded()) {
+                    String failureMessage = getString(R.string.msg_export_failure, path);
+                    Toast.makeText(getActivity(), failureMessage, Toast.LENGTH_LONG).show();
+                }
             }
         }
     };

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -1471,7 +1471,7 @@ public class AlarmListDialog extends DialogFragment
                 float eventIconSize = context.getResources().getDimension(R.dimen.eventIcon_width);
                 if (event != null)
                 {
-                    boolean northward = WidgetSettings.loadLocalizeHemispherePref(context, 0) && (item.location.getLatitudeAsDouble() < 0);
+                    boolean northward = WidgetSettings.loadLocalizeHemispherePref(context, 0) && (item.location != null) && (item.location.getLatitudeAsDouble() < 0);
                     Drawable eventIcon = SolarEventIcons.getIconDrawable(context, event, (int)eventIconSize, (int)eventIconSize, northward);
                     view.text_event.setCompoundDrawablePadding(SolarEventIcons.getIconDrawablePadding(context, event));
                     view.text_event.setCompoundDrawables(eventIcon, null, null, null);
@@ -1515,7 +1515,7 @@ public class AlarmListDialog extends DialogFragment
             {
                 boolean showLocation = (item.getEventItem(context).requiresLocation() || (item.getEvent() == null && item.timezone != null));
                 view.text_location.setVisibility(showLocation ? View.VISIBLE : View.INVISIBLE);
-                view.text_location.setText(item.location.getLabel());
+                view.text_location.setText(item.location != null ? item.location.getLabel() : "");
                 view.text_location.setTextColor(item.enabled ? color_on : color_off);
 
                 Drawable[] d = SuntimesUtils.tintCompoundDrawables(view.text_location.getCompoundDrawables(), (item.enabled ? color_on : color_off));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -598,37 +598,37 @@ public class AlarmListDialog extends DialogFragment
     ////////////////////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    public void importAlarms(Context context)
+    public void importAlarms(final Context context)
     {
         if (importTask != null && exportTask != null) {
             Log.e("ImportAlarms", "Already busy importing/exporting! ignoring request");
 
         } else {
-            Intent intent = ExportTask.getOpenFileIntent(AlarmClockItemExportTask.MIMETYPE);
-            startActivityForResult(intent, REQUEST_IMPORT_URI);
+            DialogInterface.OnClickListener onWarningAcknowledged = new DialogInterface.OnClickListener()
+            {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    Intent intent = ExportTask.getOpenFileIntent(AlarmClockItemExportTask.MIMETYPE);
+                    startActivityForResult(intent, REQUEST_IMPORT_URI);
+                }
+            };
+            if (!AppSettings.checkDialogDoNotShowAgain(context, DIALOG_IMPORT_WARNING)) {
+                AppSettings.buildAlertDialog(DIALOG_IMPORT_WARNING, getLayoutInflater(),
+                        R.drawable.ic_action_warning, context.getString(android.R.string.dialog_alert_title),
+                        context.getString(R.string.importalarms_msg_warning), onWarningAcknowledged).show();
+            } else onWarningAcknowledged.onClick(null, DialogInterface.BUTTON_POSITIVE);
         }
     }
 
-    protected void importAlarms(final Context context, @NonNull final Uri uri)
+    protected void importAlarms(final Context context, @NonNull Uri uri)
     {
         if (importTask != null && exportTask != null) {
             Log.e("ImportAlarms", "Already busy importing/exporting! ignoring request");
 
         } else if (context != null) {
-            DialogInterface.OnClickListener onWarningAcknowledged = new DialogInterface.OnClickListener()
-            {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    importTask = new AlarmClockItemImportTask(context);
-                    importTask.setTaskListener(importListener);
-                    importTask.execute(uri);
-                }
-            };
-            if (!AppSettings.checkDialogDoNotShowAgain(context, DIALOG_IMPORT_WARNING)) {
-                AppSettings.buildAlertDialog(DIALOG_IMPORT_WARNING, getLayoutInflater(),
-                        R.drawable.ic_action_warning, context.getString(R.string.dialog_title_caution),
-                        context.getString(R.string.importalarms_msg_warning), onWarningAcknowledged).show();
-            } else onWarningAcknowledged.onClick(null, DialogInterface.BUTTON_POSITIVE);
+            importTask = new AlarmClockItemImportTask(context);
+            importTask.setTaskListener(importListener);
+            importTask.execute(uri);
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmListDialog.java
@@ -512,10 +512,8 @@ public class AlarmListDialog extends DialogFragment
             {
                 if (Build.VERSION.SDK_INT >= 19)
                 {
-                    Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-                    intent.addCategory(Intent.CATEGORY_OPENABLE);
-                    intent.setType(AlarmClockItemExportTask.MIMETYPE);
-                    intent.putExtra(Intent.EXTRA_TITLE, exportTarget + AlarmClockItemExportTask.FILEEXT);
+                    String filename = exportTarget + AlarmClockItemExportTask.FILEEXT;
+                    Intent intent = ExportTask.getCreateFileIntent(filename, AlarmClockItemExportTask.MIMETYPE);
                     startActivityForResult(intent, REQUEST_EXPORT_URI);
 
                 } else {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/getfix/ExportPlacesTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/getfix/ExportPlacesTask.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2017-2019 Forrest Guice
+    Copyright (C) 2017-2022 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -22,6 +22,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
+import android.net.Uri;
 import android.util.Log;
 
 import com.forrestguice.suntimeswidget.ExportTask;
@@ -32,6 +33,9 @@ import java.io.IOException;
 
 public class ExportPlacesTask extends ExportTask
 {
+    public static final String FILEEXT = ".csv";
+    public static final String MIMETYPE = "text/csv";
+
     private Cursor cursor;
     private GetFixDatabaseAdapter db;
 
@@ -45,11 +49,16 @@ public class ExportPlacesTask extends ExportTask
         super(context, exportTarget, useExternalStorage, saveToCache);
         initTask();
     }
+    public ExportPlacesTask(Context context, Uri uri)
+    {
+        super(context, uri);
+        initTask();
+    }
 
     private void initTask()
     {
-        ext = ".csv";
-        mimeType = "text/csv";
+        ext = FILEEXT;
+        mimeType = MIMETYPE;
     }
 
     @Override
@@ -59,7 +68,6 @@ public class ExportPlacesTask extends ExportTask
         db = new GetFixDatabaseAdapter(context.getApplicationContext());
         db.open();
         numEntries = db.getPlaceCount();
-        out = new BufferedOutputStream(new FileOutputStream(exportFile));
         cursor = db.getAllPlaces(-1, true);
         return exportDatabase(db, cursor, out);
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/getfix/PlacesListFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/getfix/PlacesListFragment.java
@@ -917,24 +917,7 @@ public class PlacesListFragment extends Fragment
     {
         if (context != null)
         {
-            Intent intent;
-            if (Build.VERSION.SDK_INT >= 19)
-            {
-                intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                intent.addCategory(Intent.CATEGORY_OPENABLE);
-                intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
-
-            } else {
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-            }
-
-            if (Build.VERSION.SDK_INT >= 11) {
-                intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
-            }
-
-            intent.setType("text/*");
-            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            Intent intent = ExportTask.getOpenFileIntent("text/*");
             startActivityForResult(intent, IMPORT_REQUEST);
             return true;
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/getfix/PlacesListFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/getfix/PlacesListFragment.java
@@ -917,8 +917,24 @@ public class PlacesListFragment extends Fragment
     {
         if (context != null)
         {
-            Intent intent = new Intent((Build.VERSION.SDK_INT >= 19 ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT));
+            Intent intent;
+            if (Build.VERSION.SDK_INT >= 19)
+            {
+                intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+
+            } else {
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+            }
+
+            if (Build.VERSION.SDK_INT >= 11) {
+                intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+            }
+
             intent.setType("text/*");
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             startActivityForResult(intent, IMPORT_REQUEST);
             return true;
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/AppSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/AppSettings.java
@@ -36,6 +36,10 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.Toast;
 
 import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.calculator.SuntimesRiseSetData;
@@ -130,6 +134,9 @@ public class AppSettings
 
     public static final String PREF_KEY_PLUGINS_ENABLESCAN = "app_plugins_enabled";
     public static final boolean PREF_DEF_PLUGINS_ENABLESCAN = false;
+
+    public static final String PREF_KEY_DIALOG = "dialog";
+    public static final String PREF_KEY_DIALOG_DONOTSHOWAGAIN = "donotshowagain";
 
     /**
      * Language modes (system, user defined)
@@ -573,6 +580,46 @@ public class AppSettings
     {
         SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
         return pref.getBoolean(PREF_KEY_GETFIX_PASSIVE, PREF_DEF_GETFIX_PASSIVE);
+    }
+
+    /**
+     * @return true; dialog should not be shown (user has check 'do not show again')
+     */
+    public static boolean checkDialogDoNotShowAgain( Context context, String dialogKey ) {
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
+        return pref.getBoolean(PREF_KEY_DIALOG + "_" + dialogKey + "_" + PREF_KEY_DIALOG_DONOTSHOWAGAIN, false);
+    }
+    public static void setDialogDoNotShowAgain(Context context, String dialogKey, boolean value)
+    {
+        SharedPreferences.Editor pref = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        pref.putBoolean(PREF_KEY_DIALOG + "_" + dialogKey + "_" + PREF_KEY_DIALOG_DONOTSHOWAGAIN, value);
+        pref.apply();
+    }
+    public static AlertDialog.Builder buildAlertDialog(final String key, @NonNull LayoutInflater inflater,
+                                                       int iconResId, @Nullable String title, @NonNull String message, @Nullable final DialogInterface.OnClickListener onOkClicked)
+    {
+        final Context context = inflater.getContext();
+        View dialogView = inflater.inflate(R.layout.layout_dialog_alert, null);
+        final CheckBox check_notagain = (CheckBox) dialogView.findViewById(R.id.check_donotshowagain);
+
+        AlertDialog.Builder dialog = new AlertDialog.Builder(context);
+        if (title != null) {
+            dialog.setTitle(title);
+        }
+        dialog.setMessage(message)
+                .setView(dialogView)
+                .setCancelable(false)
+                .setPositiveButton(context.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which)
+                    {
+                        if (check_notagain != null) {
+                            AppSettings.setDialogDoNotShowAgain(context, key, check_notagain.isChecked());
+                        }
+                        onOkClicked.onClick(dialog, which);
+                    }
+                });
+        return dialog;
     }
 
     /**

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/AppSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/AppSettings.java
@@ -608,6 +608,7 @@ public class AppSettings
         }
         dialog.setMessage(message)
                 .setView(dialogView)
+                .setIcon(iconResId)
                 .setCancelable(false)
                 .setPositiveButton(context.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
                     @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/themes/ExportThemesTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/themes/ExportThemesTask.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2017-2019 Forrest Guice
+    Copyright (C) 2017-2022 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -21,11 +21,16 @@ package com.forrestguice.suntimeswidget.themes;
 import com.forrestguice.suntimeswidget.ExportTask;
 import com.forrestguice.suntimeswidget.settings.WidgetThemes;
 import android.content.Context;
+import android.net.Uri;
+
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 
 public class ExportThemesTask extends ExportTask
 {
+    public static final String FILEEXT = ".xml";
+    public static final String MIMETYPE = "text/xml";
+
     public ExportThemesTask(Context context, String exportTarget)
     {
         super(context, exportTarget);
@@ -36,11 +41,16 @@ public class ExportThemesTask extends ExportTask
         super(context, exportTarget, useExternalStorage, saveToCache);
         initTask();
     }
+    public ExportThemesTask(Context context, Uri uri)
+    {
+        super(context, uri);
+        initTask();
+    }
 
     private void initTask()
     {
-        ext = ".xml";
-        mimeType = "text/plain";
+        ext = FILEEXT;
+        mimeType = MIMETYPE;
     }
 
     private SuntimesTheme.ThemeDescriptor[] descriptors = null;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/themes/WidgetThemeListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/themes/WidgetThemeListActivity.java
@@ -367,24 +367,7 @@ public class WidgetThemeListActivity extends AppCompatActivity
                 return false;
 
             } else {
-                Intent intent;
-                if (Build.VERSION.SDK_INT >= 19)
-                {
-                    intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                    intent.addCategory(Intent.CATEGORY_OPENABLE);
-                    intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-                    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
-
-                } else {
-                    intent = new Intent(Intent.ACTION_GET_CONTENT);
-                }
-
-                if (Build.VERSION.SDK_INT >= 11) {
-                    intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
-                }
-
-                intent.setType("text/*");
-                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                Intent intent = ExportTask.getOpenFileIntent("text/*");
                 startActivityForResult(intent, IMPORT_REQUEST);
                 return true;
             }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/themes/WidgetThemeListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/themes/WidgetThemeListActivity.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2017-2019 Forrest Guice
+    Copyright (C) 2017-2022 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -36,7 +36,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
-import android.support.v4.content.FileProvider;
+import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.ActionMode;
@@ -82,6 +82,7 @@ public class WidgetThemeListActivity extends AppCompatActivity
 
     public static final int PICK_THEME_REQUEST = 1;
     public static final int IMPORT_REQUEST = 100;
+    public static final int EXPORT_REQUEST = 200;
 
     public static final String ADAPTER_MODIFIED = "isModified";
     public static final String PARAM_SELECTED = "selected";
@@ -337,7 +338,7 @@ public class WidgetThemeListActivity extends AppCompatActivity
     /**
      * @param context a context used to access resources
      */
-    private boolean exportThemes(Context context, SuntimesTheme.ThemeDescriptor[] themes)
+    protected boolean exportThemes(Context context, SuntimesTheme.ThemeDescriptor... themes)         // TODO: use SAF for single-theme export
     {
         if (context != null)
         {
@@ -355,6 +356,44 @@ public class WidgetThemeListActivity extends AppCompatActivity
         }
         return false;
     }
+    protected boolean exportThemes(Context context)
+    {
+        if (isImporting || isExporting) {
+            Log.e("exportThemes", "Already busy importing/exporting! ignoring request");
+            return false;
+        }
+
+        if (context != null)
+        {
+            String exportTarget = "SuntimesThemes";
+            if (Build.VERSION.SDK_INT >= 19)
+            {
+                String filename = exportTarget + ExportThemesTask.FILEEXT;
+                Intent intent = ExportTask.getCreateFileIntent(filename, ExportThemesTask.MIMETYPE);
+                startActivityForResult(intent, EXPORT_REQUEST);
+
+            } else {
+                exportTask = new ExportThemesTask(context, exportTarget, true, true);    // export to external cache
+                exportTask.setDescriptors(WidgetThemes.values());
+                exportTask.setTaskListener(exportThemesListener);
+                exportTask.execute();
+            }
+            return true;
+        } else return false;
+    }
+    protected void exportThemes(Context context, @NonNull Uri uri)
+    {
+        if (isImporting || isExporting) {
+            Log.e("exportThemes", "Busy! Already importing/exporting.. ignoring request");
+            return;
+        }
+
+        Log.i("exportThemes", "Starting export with uri: " + uri);
+        exportTask = new ExportThemesTask(context, uri);
+        exportTask.setDescriptors(WidgetThemes.values());
+        exportTask.setTaskListener(exportThemesListener);
+        exportTask.execute();
+    }
 
     /**
      */
@@ -367,7 +406,7 @@ public class WidgetThemeListActivity extends AppCompatActivity
                 return false;
 
             } else {
-                Intent intent = ExportTask.getOpenFileIntent("text/*");
+                Intent intent = ExportTask.getOpenFileIntent(ExportThemesTask.MIMETYPE);
                 startActivityForResult(intent, IMPORT_REQUEST);
                 return true;
             }
@@ -469,31 +508,25 @@ public class WidgetThemeListActivity extends AppCompatActivity
             isExporting = false;
             dismissProgress();
 
+            File file = results.getExportFile();
+            String path = ((file != null) ? file.getAbsolutePath() : ExportTask.getFileName(getContentResolver(), results.getExportUri()));
+
             if (results.getResult())
             {
-                Intent shareIntent = new Intent();
-                shareIntent.setAction(Intent.ACTION_SEND);
-                shareIntent.setType(results.getMimeType());
-                shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                String successMessage = getString(R.string.msg_export_success, path);
+                Toast.makeText(getApplicationContext(), successMessage, Toast.LENGTH_LONG).show();
+                // TODO: use a snackbar instead; offer 'copy path' action
 
-                try {
-                    //Uri shareURI = Uri.fromFile(results.getExportFile());  // this URI works until api26 (throws FileUriExposedException)
-                    Uri shareURI = FileProvider.getUriForFile(WidgetThemeListActivity.this, ExportTask.FILE_PROVIDER_AUTHORITY, results.getExportFile());
-                    shareIntent.putExtra(Intent.EXTRA_STREAM, shareURI);
-
-                    String successMessage = getString(R.string.msg_export_success, results.getExportFile().getAbsolutePath());
-                    Toast.makeText(getApplicationContext(), successMessage, Toast.LENGTH_LONG).show();
-
-                    startActivity(Intent.createChooser(shareIntent, getResources().getText(R.string.msg_export_to)));
-                    return;     // successful export ends here...
-
-                } catch (Exception e) {
-                    Log.e("ExportThemes", "Failed to share file URI! " + e);
+                if (Build.VERSION.SDK_INT >= 19) {
+                    if (results.getExportUri() == null) {
+                        ExportTask.shareResult(WidgetThemeListActivity.this, results.getExportFile(), results.getMimeType());
+                    }
+                } else {
+                    ExportTask.shareResult(WidgetThemeListActivity.this, results.getExportFile(), results.getMimeType());
                 }
+                return;
             }
 
-            File file = results.getExportFile();   // export failed
-            String path = ((file != null) ? file.getAbsolutePath() : "<path>");
             String failureMessage = getString(R.string.msg_export_failure, path);
             Toast.makeText(getApplicationContext(), failureMessage, Toast.LENGTH_LONG).show();
         }
@@ -552,7 +585,7 @@ public class WidgetThemeListActivity extends AppCompatActivity
                 return true;
 
             case R.id.exportThemes:
-                exportThemes(this, WidgetThemes.values());
+                exportThemes(this);
                 return true;
 
             case R.id.action_help:
@@ -654,7 +687,7 @@ public class WidgetThemeListActivity extends AppCompatActivity
                         return true;
 
                     case R.id.exportTheme:
-                        exportThemes(WidgetThemeListActivity.this, new SuntimesTheme.ThemeDescriptor[] { theme.themeDescriptor()} );
+                        exportThemes(WidgetThemeListActivity.this, theme.themeDescriptor() );
                         return true;  // TODO: messages
                 }
             }
@@ -680,6 +713,16 @@ public class WidgetThemeListActivity extends AppCompatActivity
 
             case EDIT_THEME_REQUEST:
                 onEditThemeResult(resultCode, data);
+                break;
+
+            case EXPORT_REQUEST:
+                if (resultCode == Activity.RESULT_OK)
+                {
+                    Uri uri = (data != null ? data.getData() : null);
+                    if (uri != null) {
+                        exportThemes(this, uri);
+                    }
+                }
                 break;
 
             case IMPORT_REQUEST:

--- a/app/src/main/java/com/forrestguice/suntimeswidget/themes/WidgetThemeListActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/themes/WidgetThemeListActivity.java
@@ -367,8 +367,24 @@ public class WidgetThemeListActivity extends AppCompatActivity
                 return false;
 
             } else {
-                Intent intent = new Intent((Build.VERSION.SDK_INT >= 19 ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT));
+                Intent intent;
+                if (Build.VERSION.SDK_INT >= 19)
+                {
+                    intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                    intent.addCategory(Intent.CATEGORY_OPENABLE);
+                    intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+                    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+
+                } else {
+                    intent = new Intent(Intent.ACTION_GET_CONTENT);
+                }
+
+                if (Build.VERSION.SDK_INT >= 11) {
+                    intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+                }
+
                 intent.setType("text/*");
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 startActivityForResult(intent, IMPORT_REQUEST);
                 return true;
             }

--- a/app/src/main/res/layout/layout_dialog_alert.xml
+++ b/app/src/main/res/layout/layout_dialog_alert.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView android:id="@android:id/message"
+        android:layout_width="match_parent" android:layout_height="wrap_content"
+        tools:text="a line \n another line \n and another" />
+
+    <CheckBox android:id="@+id/check_donotshowagain"
+        android:layout_width="wrap_content" android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp" android:layout_marginRight="8dp"
+        android:text="@string/dialog_msg_donotshowagain" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -839,6 +839,8 @@
     <string name="clearalarms_dialog_cancel">Cancel</string>    <!-- button -->
     <string name="clearalarms_toast_success">Alarms cleared.</string> <!-- toast msg -->
 
+    <string name="importalarms_title_warning">Import Warning</string> <!-- toast msg -->
+    <string name="importalarms_msg_warning">Imported alarms might revert some settings to defaults.\nYou may need to (re)select sounds and actions.</string> <!-- toast msg -->  <!-- TODO -->
     <string name="importalarms_toast_success">Imported <xliff:g id="alarmPlural">%s</xliff:g>.</string> <!-- toast msg -->
     <plurals name="alarmPlural">
         <item quantity="one">%d alarm</item>
@@ -2002,6 +2004,8 @@
 
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>
+    <string name="dialog_title_caution">Caution</string>   <!-- TODO -->
+    <string name="dialog_msg_donotshowagain">Do not show this message again</string>  <!-- checkbox text -->     <!-- TODO -->
 
     <!-- calculator implementations -->
     <string name="calculator_displayString_sunrisesunsetlib">github.com/mikereedell/sunrisesunsetlib-java</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -839,7 +839,11 @@
     <string name="clearalarms_dialog_cancel">Cancel</string>    <!-- button -->
     <string name="clearalarms_toast_success">Alarms cleared.</string> <!-- toast msg -->
 
-    <string name="importalarms_toast_success">Imported %s alarms.</string> <!-- toast msg -->
+    <string name="importalarms_toast_success">Imported <xliff:g id="alarmPlural">%s</xliff:g>.</string> <!-- toast msg -->
+    <plurals name="alarmPlural">
+        <item quantity="one">%d alarm</item>
+        <item quantity="other">%d alarms</item>
+    </plurals>   <!-- TODO -->
 
     <string name="alarmlabel_dialog_title">Label</string>        <!-- dialog title -->
     <string name="alarmlabel_dialog_ok">Apply</string>        <!-- button -->
@@ -1733,7 +1737,7 @@
     <string name="themesexport_dialog_message">Exporting themes to file.</string>
 
     <!-- Dialog: Import / Export -->
-    <string name="msg_export_success">Temporary copy at <xliff:g id="filepath">%s</xliff:g></string>
+    <string name="msg_export_success">Saved to <xliff:g id="filepath">%s</xliff:g></string>   <!-- TODO: update -->
     <string name="msg_export_failure">Export to <xliff:g id="filepath">%s</xliff:g> failed!</string>
     <string name="msg_export_to">Export with</string>  <!-- title displayed over "share action" chooser -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -840,7 +840,7 @@
     <string name="clearalarms_toast_success">Alarms cleared.</string> <!-- toast msg -->
 
     <string name="importalarms_title_warning">Import Warning</string> <!-- toast msg -->
-    <string name="importalarms_msg_warning">Imported alarms might revert some settings to defaults.\nYou may need to (re)select sounds and actions.</string> <!-- toast msg -->  <!-- TODO -->
+    <string name="importalarms_msg_warning">Imported alarms might revert some settings to defaults.\n\nYou may need to (re)select sounds and actions.</string> <!-- toast msg -->  <!-- TODO -->
     <string name="importalarms_toast_success">Imported <xliff:g id="alarmPlural">%s</xliff:g>.</string> <!-- toast msg -->
     <plurals name="alarmPlural">
         <item quantity="one">%d alarm</item>
@@ -2004,7 +2004,6 @@
 
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>
-    <string name="dialog_title_caution">Caution</string>   <!-- TODO -->
     <string name="dialog_msg_donotshowagain">Do not show this message again</string>  <!-- checkbox text -->     <!-- TODO -->
 
     <!-- calculator implementations -->

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -91,6 +91,12 @@
             android:summary="@string/configLabel_alarms_showlauncher_summary"
             android:defaultValue="@string/def_app_alarms_showlauncher" />
 
+        <CheckBoxPreference
+            android:key="dialog_importwarning_donotshowagain"
+            android:title="@string/importalarms_title_warning"
+            android:summary="@string/dialog_msg_donotshowagain"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -62,4 +62,15 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/configLabel_alarmMisc">
+
+        <CheckBoxPreference
+            android:key="dialog_importwarning_donotshowagain"
+            android:title="@string/importalarms_title_warning"
+            android:summary="@string/dialog_msg_donotshowagain"
+            android:defaultValue="false" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
* fixes bug where alarm import is unable to select previously exported files (#588).
* adds export file selection (alarms/places/themes) using Storage Access Framework (api19+) (older devices still use `ACTION_SEND`) (#588).
* adds import warning dialog; alarm sounds and actions may revert to defaults (#588).