### PR TITLE
release 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.14.6 (2022-06-04)
 * fixes crash when changing an alarm's time/event (#605).
-* fixes bug where despite setting units to metric the altitude is displayed in feet (#604); [Android Go]
+* fixes bug where units setting is ignored (altitude displayed in feet) (#604); [Android Go]
 * updates translation to Czech (cs) (#606 by utaxiu).
 
 ### v0.14.5 (2022-05-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.14.6 (2022-06-04)
+* fixes crash when changing an alarm's time/event (#605).
+* fixes bug where despite setting units to metric the altitude is displayed in feet (#604); [Android Go]
+* updates translation to Czech (cs) (#606 by utaxiu).
+
 ### v0.14.5 (2022-05-14)
 * fixes bug "default alarm sound fails to play" (#593); adds fallback ringtones (rtttl).
 * fixes bug "sounding/snoozing notification is unexpectedly canceled" (#594).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 89
-        versionName "0.14.5"
+        versionCode 90
+        versionName "0.14.6"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/90.txt
+++ b/fastlane/metadata/android/en-US/changelogs/90.txt
@@ -1,0 +1,3 @@
+- fixes crash when changing an alarm's time/event (#605).
+- fixes bug where units setting is ignored (altitude displayed in feet) (#604).
+- updates translation to Czech.


### PR DESCRIPTION
* fixes crash when changing an alarm's time/event (closes #605).
* fixes bug where despite setting units to metric the altitude is displayed in feet (closes #604); [Android Go]
* updates translation to Czech (cs) (#606 by utaxiu).