### PR TITLE
release 0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ### ~
 
-### v0.14.9 (2022-10-17)
+### v0.14.9 (2022-10-20)
 * fixes wrong or missing colors when using system dark mode.
+* fixes "size of sun in 2x1 and 3x1 lightmap widgets" (#624).
 * fixes lightmap "long click" to be consistent with a normal click.
-* fixes notification "dismiss" button to help improve context (#628).
+* fixes alarm notification "dismiss" label to help improve context (#628).
 * updates translation to Norwegian (nb) (#632 by FTno).
 * updates translation to German (de) (#631 by CSTRSK).
 * updates translation to Czech (cs) (#630 by utaxiu).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.14.9 (2022-10-20)
+### v0.14.9 (2022-10-23)
 * adds "update all" to widget actions (#625).
 * fixes app crash when the default alarm ringtone is unavailable (#634).
 * fixes wrong/missing colors when using system dark mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### ~
 
 ### v0.14.9 (2022-10-20)
+* adds "update all" to widget actions (#625).
 * fixes app crash when the default alarm ringtone is unavailable (#634).
 * fixes wrong/missing colors when using system dark mode.
 * fixes "size of sun in 2x1 and 3x1 lightmap widgets" (#624).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### ~
 
+### v0.14.9 (2022-10-17)
+* fixes wrong or missing colors when using system dark mode.
+* fixes lightmap "long click" to be consistent with a normal click.
+* fixes notification "dismiss" button to help improve context (#628).
+* updates translation to Norwegian (nb) (#632 by FTno).
+* updates translation to German (de) (#631 by CSTRSK).
+* updates translation to Czech (cs) (#630 by utaxiu).
+
 ### v0.14.8 (2022-09-26)
 * fixes crash when location is set to high latitudes (#623).
 * fixes appearance of location icons when using system dark mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### ~
 
 ### v0.14.9 (2022-10-20)
-* fixes wrong or missing colors when using system dark mode.
+* fixes app crash when the default alarm ringtone is unavailable (#634).
+* fixes wrong/missing colors when using system dark mode.
 * fixes "size of sun in 2x1 and 3x1 lightmap widgets" (#624).
 * fixes lightmap "long click" to be consistent with a normal click.
 * fixes alarm notification "dismiss" label to help improve context (#628).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 92
-        versionName "0.14.8"
+        versionCode 93
+        versionName "0.14.9"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -290,8 +290,7 @@ public class AlarmSettings
     public static String getDefaultRingtoneName(Context context, AlarmClockItem.AlarmType type)
     {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String name = prefs.getString((type == AlarmClockItem.AlarmType.ALARM) ? PREF_KEY_ALARM_RINGTONE_NAME_ALARM : PREF_KEY_ALARM_RINGTONE_NAME_NOTIFICATION, context.getString(R.string.configLabel_tagDefault));
-        return (name != null) ? name : context.getString(R.string.configLabel_tagDefault);
+        return prefs.getString((type == AlarmClockItem.AlarmType.ALARM) ? PREF_KEY_ALARM_RINGTONE_NAME_ALARM : PREF_KEY_ALARM_RINGTONE_NAME_NOTIFICATION, context.getString(R.string.configLabel_tagDefault));
     }
 
     @Nullable

--- a/fastlane/metadata/android/en-US/changelogs/93.txt
+++ b/fastlane/metadata/android/en-US/changelogs/93.txt
@@ -1,3 +1,4 @@
+- adds "update all" to widget actions (#625).
 - fixes crash when the default alarm ringtone is unavailable (#634).
 - updates translation to Czech.
 - updates translation to German.

--- a/fastlane/metadata/android/en-US/changelogs/93.txt
+++ b/fastlane/metadata/android/en-US/changelogs/93.txt
@@ -1,0 +1,3 @@
+- updates translation to Czech.
+- updates translation to German.
+- updates translation to Norwegian.

--- a/fastlane/metadata/android/en-US/changelogs/93.txt
+++ b/fastlane/metadata/android/en-US/changelogs/93.txt
@@ -1,3 +1,4 @@
+- fixes crash when the default alarm ringtone is unavailable (#634).
 - updates translation to Czech.
 - updates translation to German.
 - updates translation to Norwegian.


### PR DESCRIPTION
* adds "update all" to widget actions (#625).
* fixes app crash when the default alarm ringtone is unavailable (fixes #633).
* fixes wrong/missing colors when using system dark mode.
* fixes "size of sun in 2x1 and 3x1 lightmap widgets" (fixes #624).
* fixes lightmap "long click" to be consistent with a normal click.
* fixes alarm notification "dismiss" label to help improve context (#628).
* updates translation to Norwegian (nb) (#632 by FTno).
* updates translation to German (de) (#631 by CSTRSK).
* updates translation to Czech (cs) (#630 by utaxiu).