### PR TITLE
release 0.14.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### ~
 
+### v0.14.10 (2022-11-08)
+* adds "abbreviated month names" widget option (#625).
+* adds a help dialog to the alarm edit activity (#628); adds "day light saving" to main help dialog.
+* fixes bug "alarms do not compensate for time zone changes" (#643).
+* fixes bug "BOOT_COMPLETED fails to reschedule stale alarms" (#641).
+* fixes bug where the "light theme" is only partially applied (when system dark mode is also enabled).
+* fixes 3x1 sun position widget "scale text and icons" option; changes labels to bold for better readability (#625).
+
 ### v0.14.9 (2022-10-26)
 * adds "update all" to widget actions (#625).
 * adds a warning to SuntimesAlarms when battery optimization is enabled (api23+), or STAMINA mode is enabled (sony devices only).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 93
-        versionName "0.14.9"
+        versionCode 94
+        versionName "0.14.10"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/94.txt
+++ b/fastlane/metadata/android/en-US/changelogs/94.txt
@@ -1,0 +1,8 @@
+- adds "update all" to widget actions.
+- adds "abbreviated month names" widget option.
+- fixes crash when the default alarm ringtone is unavailable (#634).
+- fixes bug "BOOT_COMPLETED fails to reschedule stale alarms" (#641).
+- fixes bug "alarms do not compensate for time zone changes" (#643).
+- updates translation to Czech.
+- updates translation to German.
+- updates translation to Norwegian.


### PR DESCRIPTION
* adds "abbreviated month names" widget option (#625).
* adds a help dialog to the alarm edit activity (#628); adds "day light saving" to main help dialog.
* fixes bug "alarms do not compensate for time zone changes" (fixes #643).
* fixes bug "BOOT_COMPLETED fails to reschedule stale alarms" (fixes #641).
* fixes bug where the "light theme" is only partially applied (when system dark mode is also enabled).
* fixes 3x1 sun position widget "scale text and icons" option; changes labels to bold for better readability (#625).