### PR TITLE
request ignore battery optimizations [permission]

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,7 @@
 name: Android CI
 
 on: 
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -20,17 +19,29 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1.0.4
     - name: Make gradlew executable
       run: chmod +x ./gradlew
+    
+    - uses: actions/cache@v2
+      with:
+        path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+            ${{ runner.os }}-gradle-
+    
     - name: Build with Gradle
       run: ./gradlew build
+    
     - name: Upload artifacts (apk)
       uses: actions/upload-artifact@v3.0.0
       with:
         name: app
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: app/build/outputs/apk/debug/app-debug.apk    
     - name: Upload artifacts (lint results)
       uses: actions/upload-artifact@v3.0.0
       with:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The app benefits from the following permissions...
 |POWER_OFF_ALARM|To wake the device from the power off state.|v0.14.0|
 |READ_EXTERNAL_STORAGE|To play alarm sounds located on the SD card.|v0.11.5, v0.13.8 (api&le;18)|
 |SET_ALARM|To interact with the system AlarmClock app.|v0.1.0|
+|REQUEST_IGNORE_BATTERY_OPTIMIZATIONS|To help ensure reliable delivery of alarms.|v0.14.11|
 |WRITE_EXTERNAL_STORAGE|To export data (places, themes, etc.) to file.|v0.2.2 (api&le;18)|
 
 Version `v0.13.8` removed READ_EXTERNAL_STORAGE for api&ge;19 (replaced with persistent URI permissions). 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,15 +17,7 @@
 
     <uses-permission android:name="org.codeaurora.permission.POWER_OFF_ALARM" />  <!-- needed for hardware dependent 'power off' alarms -->
 
-    <!--
-       REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-       This permission is discouraged (and prohibited by Play Store policies). We are declaring it
-       here anyway to see if it helps improve alarm reliability on problematic devices.
-
-       * https://developer.android.com/reference/android/provider/Settings.html#ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-       * https://stackoverflow.com/questions/44862176/request-ignore-battery-optimizations-how-to-do-it-right
-       -->
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />  <!-- needed for reliable delivery of alarms and notifications -->
 
     <permission
         android:name="suntimes.permission.READ_CALCULATOR"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,17 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />  <!-- needed by AlarmClock to restore alarms after shutdown/reboot -->
 
     <uses-permission android:name="org.codeaurora.permission.POWER_OFF_ALARM" />  <!-- needed for hardware dependent 'power off' alarms -->
-    
+
+    <!--
+       REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+       This permission is discouraged (and prohibited by Play Store policies). We are declaring it
+       here anyway to see if it helps improve alarm reliability on problematic devices.
+
+       * https://developer.android.com/reference/android/provider/Settings.html#ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+       * https://stackoverflow.com/questions/44862176/request-ignore-battery-optimizations-how-to-do-it-right
+       -->
+    <uses-permission android:name="android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <permission
         android:name="suntimes.permission.READ_CALCULATOR"
         android:protectionLevel="normal" />                       <!-- protects suntimeswidget.calculator.provider -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
        * https://developer.android.com/reference/android/provider/Settings.html#ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
        * https://stackoverflow.com/questions/44862176/request-ignore-battery-optimizations-how-to-do-it-right
        -->
-    <uses-permission android:name="android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <permission
         android:name="suntimes.permission.READ_CALCULATOR"

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -24,6 +24,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.KeyguardManager;
 import android.app.ProgressDialog;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -1832,12 +1833,42 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
        return new Preference.OnPreferenceClickListener() {
            @Override
            public boolean onPreferenceClick(Preference preference) {
-               if (Build.VERSION.SDK_INT >= 23) {
-                   context.startActivity(new Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS));
-               }
+               openBatteryOptimizationSettings(context);
                return false;
            }
        };
+    }
+
+    public static void openBatteryOptimizationSettings(final Context context)
+    {
+        if (Build.VERSION.SDK_INT >= 23)
+        {
+            try {
+                //context.startActivity(getRequestIgnoreBatteryOptimizationSettingsIntent(context));
+                context.startActivity(getRequestIgnoreBatteryOptimizationIntent(context));
+
+            } catch (ActivityNotFoundException e) {
+                Log.e(LOG_TAG, "Failed to launch battery optimization Intent: " + e);
+            }
+        }
+    }
+
+    /**
+     * Recommended; this Intent shows the optimization list (and the user must find and select the app)
+     */
+    @TargetApi(23)
+    public static Intent getRequestIgnoreBatteryOptimizationSettingsIntent(Context context) {
+        return new Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+    }
+
+    /**
+     * Discouraged; this Intent goes directly to the app's optimization settings.
+     * Requires permission `android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
+     */
+    @TargetApi(23)
+    @Deprecated
+    public static Intent getRequestIgnoreBatteryOptimizationIntent(Context context) {
+        return new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, Uri.parse("package:" + context.getPackageName()));
     }
 
     protected static boolean isDeviceSecure(Context context)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1841,14 +1841,21 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
 
     public static void openBatteryOptimizationSettings(final Context context)
     {
-        if (Build.VERSION.SDK_INT >= 23)
-        {
+        if (Build.VERSION.SDK_INT >= 23) {
             try {
-                //context.startActivity(getRequestIgnoreBatteryOptimizationSettingsIntent(context));
-                context.startActivity(getRequestIgnoreBatteryOptimizationIntent(context));
-
+                context.startActivity(getRequestIgnoreBatteryOptimizationSettingsIntent(context));
             } catch (ActivityNotFoundException e) {
-                Log.e(LOG_TAG, "Failed to launch battery optimization Intent: " + e);
+                Log.e(LOG_TAG, "Failed to launch battery optimization settings Intent: " + e);
+            }
+        }
+    }
+    public static void requestIgnoreBatteryOptimization(final Context context)
+    {
+        if (Build.VERSION.SDK_INT >= 23) {
+            try {
+                context.startActivity( getRequestIgnoreBatteryOptimizationIntent(context));
+            } catch (ActivityNotFoundException e) {
+                Log.e(LOG_TAG, "Failed to launch battery optimization request Intent: " + e);
             }
         }
     }
@@ -1862,11 +1869,10 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
     }
 
     /**
-     * Discouraged; this Intent goes directly to the app's optimization settings.
+     * This Intent goes directly to the app's optimization settings.
      * Requires permission `android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
      */
     @TargetApi(23)
-    @Deprecated
     public static Intent getRequestIgnoreBatteryOptimizationIntent(Context context) {
         return new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, Uri.parse("package:" + context.getPackageName()));
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -902,9 +902,7 @@ public class AlarmClockActivity extends AppCompatActivity
             {
                 @Override
                 public void onClick(View view) {
-                    if (Build.VERSION.SDK_INT >= 23) {
-                        startActivity(new Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS));
-                    }
+                    SuntimesSettingsActivity.openBatteryOptimizationSettings(AlarmClockActivity.this);
                 }
             });
             batteryOptimizationWarning.show();


### PR DESCRIPTION
* adds permission `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`

This permission is added for overall better UX, making it is significantly easier for users to whitelist the app (required for reliable alarms). Suntimes is a clock app and alarms are one of its core functionalities, so [use of this permission is justified](https://developer.android.com/training/monitoring-device-state/doze-standby#support_for_other_use_cases).