### PR TITLE
alarms battery optimization warning

### DIFF
--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1905,9 +1905,9 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
                             public void onClick(DialogInterface dialog, int which)
                             {
                                 String url = context.getString(R.string.help_battery_optimization_url);
-                                if (isAggressive) {
+                                /*if (isAggressive) {
                                     url += "-" + Build.MANUFACTURER;
-                                }
+                                }*/
                                 context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
                             }
                         });

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1650,7 +1650,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
                     String listed = context.getString(R.string.configLabel_alarms_optWhiteList_listed);
                     batteryOptimization.setSummary(listed);
                 } else {
-                    String unlisted = context.getString(R.string.configLabel_alarms_optWhiteList_unlisted);
+                    String unlisted = context.getString(AlarmSettings.aggressiveBatteryOptimizations(context) ? R.string.configLabel_alarms_optWhiteList_unlisted_aggressive : R.string.configLabel_alarms_optWhiteList_unlisted);
                     batteryOptimization.setSummary(SuntimesUtils.createColorSpan(null, unlisted, unlisted, colorWarning));
                 }
                 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -406,6 +406,22 @@ public class AlarmSettings
         } else return true;
     }
 
+    /***
+     * Some device manufacturers are worse than others; https://dontkillmyapp.com/
+     * This method checks the device manufacturer against a list of known offenders.
+     * @return true this device is likely to have aggressive (alarm breaking) battery optimizations
+     */
+    public static boolean aggressiveBatteryOptimizations(Context context)
+    {
+        String[] manufacturers = context.getResources().getStringArray(R.array.aggressive_battery_known_offenders);
+        for (String manufacturer : manufacturers) {
+            if (manufacturer != null && manufacturer.equalsIgnoreCase(Build.MANUFACTURER)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * https://dontkillmyapp.com/sony
      * @return true device is sony and "stamina mode" is enabled, false device is not sony or "stamina mode" is disabled

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -897,7 +897,8 @@ public class AlarmClockActivity extends AppCompatActivity
         if (showWarnings && batteryOptimizationWarning != null
                 && batteryOptimizationWarning.shouldShow() && !batteryOptimizationWarning.wasDismissed())
         {
-            batteryOptimizationWarning.initWarning(this, addButton, "[w] " + getString(R.string.configLabel_alarms_optWhiteList_unlisted));
+            String message = getString(AlarmSettings.aggressiveBatteryOptimizations(this) ? R.string.configLabel_alarms_optWhiteList_unlisted_aggressive : R.string.configLabel_alarms_optWhiteList_unlisted);
+            batteryOptimizationWarning.initWarning(this, addButton, "[w] " + message);
             batteryOptimizationWarning.getSnackbar().setAction(getString(R.string.configLabel_alarms_optWhiteList), new View.OnClickListener()
             {
                 @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -903,7 +903,7 @@ public class AlarmClockActivity extends AppCompatActivity
             {
                 @Override
                 public void onClick(View view) {
-                    SuntimesSettingsActivity.openBatteryOptimizationSettings(AlarmClockActivity.this);
+                    SuntimesSettingsActivity.createBatteryOptimizationAlertDialog(AlarmClockActivity.this).show();
                 }
             });
             batteryOptimizationWarning.show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -880,6 +880,7 @@
     <string name="configLabel_alarms_optWhiteList_unlisted">Optimizing battery use.\nAlarms may be delayed up to 15 minutes.</string>
     <string name="sonyStaminaModeWarning"><xliff:g id="warningTag">[w]</xliff:g> Sony STAMINA mode is enabled.\nAlarms may fail to work reliably.</string>  <!-- snackbar message (sony devices only) -->   <!-- TODO -->
 
+    <string name="configLabel_alarms_optWhiteList_unlisted_aggressive">Optimizing battery use.\nAlarms may fail to work reliably.</string>   <!-- TODO -->
     <string-array name="aggressive_battery_known_offenders" translatable="false">    <!-- device manufacturer id; a warning will be displayed for these devices -->
         <item>Samsung</item>
         <item>OnePlus</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -880,6 +880,24 @@
     <string name="configLabel_alarms_optWhiteList_unlisted">Optimizing battery use.\nAlarms may be delayed up to 15 minutes.</string>
     <string name="sonyStaminaModeWarning"><xliff:g id="warningTag">[w]</xliff:g> Sony STAMINA mode is enabled.\nAlarms may fail to work reliably.</string>  <!-- snackbar message (sony devices only) -->   <!-- TODO -->
 
+    <string-array name="aggressive_battery_known_offenders" translatable="false">    <!-- device manufacturer id; a warning will be displayed for these devices -->
+        <item>Samsung</item>
+        <item>OnePlus</item>
+        <item>Huawei</item>
+        <item>Xiaomi</item>
+        <item>Meizu</item>
+        <item>Asus</item>
+        <item>WIKO</item>
+        <item>LENOVO</item>
+        <item>OPPO</item>
+        <item>Vivo</item>
+        <item>realme</item>
+        <item>Blackview</item>
+        <item>Sony</item>
+        <item>Unihertz</item>
+        <!--<item>Google</item>--> <!-- uncomment to test with emulator -->
+    </string-array>
+
     <string name="configLabel_alarms_notifications">Notifications</string>
     <string name="configLabel_alarms_notifications_on">On</string>
     <string name="configLabel_alarms_notifications_off">Off.\nAlarms may fail to display correctly.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -881,6 +881,10 @@
     <string name="sonyStaminaModeWarning"><xliff:g id="warningTag">[w]</xliff:g> Sony STAMINA mode is enabled.\nAlarms may fail to work reliably.</string>  <!-- snackbar message (sony devices only) -->   <!-- TODO -->
 
     <string name="configLabel_alarms_optWhiteList_unlisted_aggressive">Optimizing battery use.\nAlarms may fail to work reliably.</string>   <!-- TODO -->
+    <string name="help_battery_optimization"><xliff:g id="appName">%s</xliff:g> must be \"not optimized\" for best results.</string>  <!-- TODO -->
+    <string name="help_battery_optimization_aggressive">This is a <xliff:g id="manufacturer" example="Samsung">%s</xliff:g> device, which may require additional configuration to work correctly.</string>  <!-- TODO -->
+
+    <string name="help_battery_optimization_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/wiki/Help#alarms</string>  <!-- TODO -->
     <string-array name="aggressive_battery_known_offenders" translatable="false">    <!-- device manufacturer id; a warning will be displayed for these devices -->
         <item>Samsung</item>
         <item>OnePlus</item>
@@ -898,7 +902,7 @@
         <item>Unihertz</item>
         <!--<item>Google</item>--> <!-- uncomment to test with emulator -->
     </string-array>
-
+    
     <string name="configLabel_alarms_notifications">Notifications</string>
     <string name="configLabel_alarms_notifications_on">On</string>
     <string name="configLabel_alarms_notifications_off">Off.\nAlarms may fail to display correctly.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -884,7 +884,7 @@
     <string name="help_battery_optimization"><xliff:g id="appName">%s</xliff:g> must be \"not optimized\" for best results.</string>  <!-- TODO -->
     <string name="help_battery_optimization_aggressive">This is a <xliff:g id="manufacturer" example="Samsung">%s</xliff:g> device, which may require additional configuration to work correctly.</string>  <!-- TODO -->
 
-    <string name="help_battery_optimization_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/wiki/Help#alarms</string>  <!-- TODO -->
+    <string name="help_battery_optimization_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/wiki/Help#battery-optimization</string>  <!-- TODO -->
     <string-array name="aggressive_battery_known_offenders" translatable="false">    <!-- device manufacturer id; a warning will be displayed for these devices -->
         <item>Samsung</item>
         <item>OnePlus</item>


### PR DESCRIPTION
* adds a help dialog that explains battery optimization warnings and links to online help.
* shows a revised warning message for devices that are likely to break alarms.
* the app now makes a direct request to ignore battery optimizations (if `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` is granted).

