### PR TITLE
alarms reboot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -287,6 +287,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
                 <!--<action android:name="android.intent.action.TIME_SET" />-->
             </intent-filter>
             <intent-filter>

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1613,17 +1613,15 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
 
                 if (action != null)
                 {
-                    if (action.equals(AlarmNotifications.ACTION_UPDATE_UI)) {
-                        if (data != null)
-                        {
-                            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
-                                @Override
-                                public void run() {
-                                    AlarmPrefsFragment.this.setBootCompletedPrefEnabled(true);
-                                    initPref_alarms_bootCompleted(AlarmPrefsFragment.this);
-                                }
-                            }, 500);
-                        } else Log.e(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: null data!");
+                    if (action.equals(AlarmNotifications.ACTION_UPDATE_UI))
+                    {
+                        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                AlarmPrefsFragment.this.setBootCompletedPrefEnabled(true);
+                                initPref_alarms_bootCompleted(AlarmPrefsFragment.this);
+                            }
+                        }, 500);
                     } else Log.e(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: unrecognized action: " + action);
                 } else Log.e(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: null action!");
             }
@@ -1633,7 +1631,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
         public void onResume()
         {
             super.onResume();
-            getActivity().registerReceiver(updateAlarmPrefsReceiver, AlarmNotifications.getUpdateBroadcastIntentFilter());
+            getActivity().registerReceiver(updateAlarmPrefsReceiver, AlarmNotifications.getUpdateBroadcastIntentFilter(false));
             initPref_alarms(AlarmPrefsFragment.this);
         }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -24,7 +24,9 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.KeyguardManager;
 import android.app.ProgressDialog;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
+import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -34,6 +36,8 @@ import android.content.res.TypedArray;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
@@ -126,6 +130,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
     private Context context;
     private PlacesPrefsBase placesPrefBase = null;
     private String appTheme = null;
+    private static SuntimesUtils utils = new SuntimesUtils();
 
     public SuntimesSettingsActivity()
     {
@@ -323,6 +328,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
 
     private void initLocale(Bundle icicle)
     {
+        SuntimesUtils.initDisplayStrings(context);
         WidgetSettings.initDefaults(context);
 
         AppSettings.initDisplayStrings(context);
@@ -1596,11 +1602,45 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
             }
         }
 
+        private final BroadcastReceiver updateAlarmPrefsReceiver = new BroadcastReceiver()
+        {
+            @Override
+            public void onReceive(Context context, Intent intent)
+            {
+                String action = intent.getAction();
+                Uri data = intent.getData();
+                Log.d(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: " + data + " :: " + action);
+
+                if (action != null)
+                {
+                    if (action.equals(AlarmNotifications.ACTION_UPDATE_UI)) {
+                        if (data != null)
+                        {
+                            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                                @Override
+                                public void run() {
+                                    AlarmPrefsFragment.this.setBootCompletedPrefEnabled(true);
+                                    initPref_alarms_bootCompleted(AlarmPrefsFragment.this);
+                                }
+                            }, 500);
+                        } else Log.e(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: null data!");
+                    } else Log.e(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: unrecognized action: " + action);
+                } else Log.e(LOG_TAG, "updateAlarmPrefsReceiver.onReceive: null action!");
+            }
+        };
+
         @Override
         public void onResume()
         {
             super.onResume();
+            getActivity().registerReceiver(updateAlarmPrefsReceiver, AlarmNotifications.getUpdateBroadcastIntentFilter());
             initPref_alarms(AlarmPrefsFragment.this);
+        }
+
+        @Override
+        public void onPause() {
+            getActivity().unregisterReceiver(updateAlarmPrefsReceiver);
+            super.onPause();
         }
 
         public static final int REQUEST_PERMISSION_POWEROFFALARMS = 100;
@@ -1615,6 +1655,14 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
         }
         @Override
         public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {}
+
+        protected void setBootCompletedPrefEnabled(boolean value)
+        {
+            final Preference pref = findPreference(AlarmSettings.PREF_KEY_ALARM_BOOTCOMPLETED);
+            if (pref != null) {
+                pref.setEnabled(value);
+            }
+        }
     }
 
     private void initPref_alarms()
@@ -1633,9 +1681,10 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
             return;
         }
 
-        int[] colorAttrs = { R.attr.tagColor_warning };
+        int[] colorAttrs = { R.attr.tagColor_warning, R.attr.text_accentColor };
         TypedArray typedArray = context.obtainStyledAttributes(colorAttrs);
         int colorWarning = ContextCompat.getColor(context, typedArray.getResourceId(0, R.color.warningTag_dark));
+        int accentColor = ContextCompat.getColor(context, typedArray.getResourceId(1,  R.color.text_accent_dark));
         typedArray.recycle();
 
         Preference batteryOptimization = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BATTERYOPT);
@@ -1706,6 +1755,8 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
             powerOffAlarmsPref.setSummary(context.getString(R.string.configLabel_alarms_poweroffalarms_summary, findPermission(context, AlarmNotifications.PERMISSION_POWEROFFALARM)));
         }
 
+        initPref_alarms_bootCompleted(fragment);
+
         Preference showLauncher = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_SHOWLAUNCHER);
         if (showLauncher != null)
         {
@@ -1726,6 +1777,49 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
                     return false;
                 }
             });
+        }
+    }
+
+    private static void initPref_alarms_bootCompleted(final AlarmPrefsFragment fragment)
+    {
+        final Context context = fragment.getActivity();
+        if (context == null) {
+            return;
+        }
+
+        final Preference bootCompletedPref = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BOOTCOMPLETED);
+        if (bootCompletedPref != null)
+        {
+            bootCompletedPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener()
+            {
+                @Override
+                public boolean onPreferenceClick(Preference preference)
+                {
+                    AlertDialog.Builder confirm = new AlertDialog.Builder(context)
+                            .setMessage(context.getString(R.string.configLabel_alarms_bootcompleted_action_confirm))
+                            .setIcon(android.R.drawable.ic_dialog_alert)
+                            .setPositiveButton(context.getString(R.string.dialog_ok), new DialogInterface.OnClickListener()
+                            {
+                                public void onClick(DialogInterface dialog, int whichButton)
+                                {
+                                    bootCompletedPref.setEnabled(false);
+                                    context.sendBroadcast(new Intent(AlarmNotifications.getAlarmIntent(context, AlarmNotifications.ACTION_SCHEDULE, null)));
+                                }
+                            })
+                            .setNegativeButton(context.getString(R.string.dialog_cancel), null);
+                    confirm.show();
+                    return true;
+                }
+            });
+
+            AlarmSettings.BootCompletedInfo bootCompletedInfo = AlarmSettings.loadPrefLastBootCompleted(context);
+            long lastRunMillis = bootCompletedInfo.getTimeMillis();
+            String lastBootCompleted = utils.calendarDateTimeDisplayString(context, lastRunMillis).toString();
+            String afterDelay = (lastRunMillis >= 0 ? utils.timeDeltaLongDisplayString(0, bootCompletedInfo.getAtElapsedMillis(), true).getValue() : "");
+            String took = (lastRunMillis >= 0 ? bootCompletedInfo.getDurationMillis() + "ms": "");
+            CharSequence infoSpan = (lastRunMillis >= 0 ? context.getString(R.string.configLabel_alarms_bootcompleted_info, lastBootCompleted, afterDelay, took)
+                    : context.getString(R.string.configLabel_alarms_bootcompleted_info_never));
+            bootCompletedPref.setSummary(context.getString(R.string.configLabel_alarms_bootcompleted_summary, infoSpan));
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1781,6 +1781,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity implements Shar
         }
     }
 
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     private static void initPref_alarms_bootCompleted(final AlarmPrefsFragment fragment)
     {
         final Context context = fragment.getActivity();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -1203,7 +1203,7 @@ public class AlarmNotifications extends BroadcastReceiver
                     itemTask.execute(ContentUris.parseId(data));
 
                 } else {
-                    if (AlarmNotifications.ACTION_SCHEDULE.equals(action) || Intent.ACTION_BOOT_COMPLETED.equals(action))
+                    if (AlarmNotifications.ACTION_SCHEDULE.equals(action) || Intent.ACTION_BOOT_COMPLETED.equals(action) || Intent.ACTION_MY_PACKAGE_REPLACED.equals(action))
                     {
                         Log.d(TAG, action + ": schedule all (prevCompleted=" + AlarmSettings.bootCompletedWasRun(getApplicationContext()) + ")");
                         final long startTime = SystemClock.elapsedRealtime();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -435,11 +435,16 @@ public class AlarmNotifications extends BroadcastReceiver
         return intent;
     }
 
-    public static IntentFilter getUpdateBroadcastIntentFilter()
+    public static IntentFilter getUpdateBroadcastIntentFilter() {
+        return getUpdateBroadcastIntentFilter(true);
+    }
+    public static IntentFilter getUpdateBroadcastIntentFilter(boolean withData)
     {
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_UPDATE_UI);
-        filter.addDataScheme("content");
+        if (withData) {
+            filter.addDataScheme("content");
+        }
         return filter;
     }
 
@@ -1228,6 +1233,7 @@ public class AlarmNotifications extends BroadcastReceiver
                                             @Override
                                             public void run() {
                                                 notifications.dismissNotification(getApplicationContext(), NOTIFICATION_SCHEDULE_ALL_ID);
+                                                sendBroadcast(getFullscreenBroadcast(null));
                                                 notifications.stopSelf(startId);
                                             }
                                         }, (ids.length > 0 ? NOTIFICATION_SCHEDULE_ALL_DURATION : 0));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -1213,7 +1213,7 @@ public class AlarmNotifications extends BroadcastReceiver
                         alarmListTask.setParam_enabledOnly(true);
                         alarmListTask.setAlarmItemTaskListener(new AlarmDatabaseAdapter.AlarmListTask.AlarmListTaskListener() {
                             @Override
-                            public void onItemsLoaded(Long[] ids)
+                            public void onItemsLoaded(final Long[] ids)
                             {
                                 final AlarmDatabaseAdapter.AlarmListObserver observer = new AlarmDatabaseAdapter.AlarmListObserver(ids, new AlarmDatabaseAdapter.AlarmListObserver.AlarmListObserverListener()
                                 {
@@ -1230,7 +1230,7 @@ public class AlarmNotifications extends BroadcastReceiver
                                                 notifications.dismissNotification(getApplicationContext(), NOTIFICATION_SCHEDULE_ALL_ID);
                                                 notifications.stopSelf(startId);
                                             }
-                                        }, NOTIFICATION_SCHEDULE_ALL_DURATION);
+                                        }, (ids.length > 0 ? NOTIFICATION_SCHEDULE_ALL_DURATION : 0));
                                     }
                                 });
 
@@ -1329,7 +1329,7 @@ public class AlarmNotifications extends BroadcastReceiver
             return new AlarmDatabaseAdapter.AlarmListTask.AlarmListTaskListener()
             {
                 @Override
-                public void onItemsLoaded(Long[] ids)
+                public void onItemsLoaded(final Long[] ids)
                 {
                     final long startedAt = System.currentTimeMillis();
                     final AlarmDatabaseAdapter.AlarmListObserver observer = new AlarmDatabaseAdapter.AlarmListObserver(ids, new AlarmDatabaseAdapter.AlarmListObserver.AlarmListObserverListener() {
@@ -1345,7 +1345,7 @@ public class AlarmNotifications extends BroadcastReceiver
                                     notifications.dismissNotification(getApplicationContext(), NOTIFICATION_SCHEDULE_ALL_ID);
                                     notifications.stopSelf(startId);
                                 }
-                            }, NOTIFICATION_SCHEDULE_ALL_DURATION);
+                            }, (ids.length > 0 ? NOTIFICATION_SCHEDULE_ALL_DURATION : 0));
                         }
                     });
                     if (ids.length == 0) {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -1197,7 +1197,6 @@ public class AlarmNotifications extends BroadcastReceiver
                                         final long duration = endTime - startTime;
                                         AlarmSettings.savePrefLastBootCompleted_finished(getApplicationContext(), System.currentTimeMillis(), duration);
                                         Log.d(TAG, "schedule all completed (took " + duration + "ms); " + AlarmSettings.bootCompletedWasRun(getApplicationContext()));
-                                        sendBroadcast(getFullscreenBroadcast(Uri.parse("content:")));  // trigger ui update
                                         notifications.stopSelf(startId);
                                     }
                                 });
@@ -1802,6 +1801,7 @@ public class AlarmNotifications extends BroadcastReceiver
                     {
                         Log.d(TAG, "State Saved (onScheduledNotification)");
                         addAlarmTimeout(context, ACTION_SHOW, item.getUri(), item.alarmtime);
+                        context.sendBroadcast(getFullscreenBroadcast(item.getUri()));
                     }
                     if (chained != null) {
                         chained.onFinished(true, item);
@@ -1825,6 +1825,7 @@ public class AlarmNotifications extends BroadcastReceiver
                         addAlarmTimeout(context, ACTION_SHOW, item.getUri(), item.alarmtime);
                         //context.startActivity(getAlarmListIntent(context, item.rowID));   // open the alarm list
                         notifications.dismissNotification(context, (int)item.rowID);
+                        context.sendBroadcast(getFullscreenBroadcast(item.getUri()));
 
                         findUpcomingAlarm(context, new AlarmDatabaseAdapter.AlarmListTask.AlarmListTaskListener() {
                             @Override
@@ -1859,6 +1860,7 @@ public class AlarmNotifications extends BroadcastReceiver
                         if (AlarmSettings.loadPrefAlarmUpcoming(context) > 0) {
                             notifications.showNotification(context, item, true);             // show upcoming reminder
                         }
+                        context.sendBroadcast(getFullscreenBroadcast(item.getUri()));
 
                         findUpcomingAlarm(context, new AlarmDatabaseAdapter.AlarmListTask.AlarmListTaskListener() {
                             @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -17,6 +17,7 @@
 */
 package com.forrestguice.suntimeswidget.alarmclock;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -28,6 +29,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.PowerManager;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.provider.OpenableColumns;
 import android.support.annotation.NonNull;
@@ -90,6 +92,11 @@ public class AlarmSettings
     public static final boolean PREF_DEF_ALARM_POWEROFFALARMS = false;
 
     public static final String PREF_KEY_ALARM_UPCOMING_ALARMID = "app_alarms_upcomingAlarmId";    // the alarm we expect to go off next (cached value)
+
+    public static final String PREF_KEY_ALARM_BOOTCOMPLETED = "app_alarms_bootcompleted";                       // timestamp of boot_completed event
+    public static final String PREF_KEY_ALARM_BOOTCOMPLETED_ATELAPSED = "app_alarms_bootcompleted_elapsed";     // elapsed time of boot_completed event (and delay time before running)
+    public static final String PREF_KEY_ALARM_BOOTCOMPLETED_DURATION = "app_alarms_bootcompleted_duration";     // boot_completed run time (milliseconds)
+    public static final String PREF_KEY_ALARM_BOOTCOMPLETED_RESULT = "app_alarms_bootcompleted_result";         // bool; true boot_completed finished, false it either never ran or failed to complete (cleared on ACTION_SHUTDOWN)
 
     public static final String PREF_KEY_ALARM_SYSTEM_TIMEZONE_ID = "app_alarms_systemtz_id";
     public static final String PREF_KEY_ALARM_SYSTEM_TIMEZONE_OFFSET = "app_alarms_systemtz_offset";
@@ -420,6 +427,77 @@ public class AlarmSettings
     }
     public static boolean isSony() {
         return "sony".equalsIgnoreCase(Build.MANUFACTURER);
+    }
+
+    /**
+     * BootCompletedInfo
+     */
+    public static class BootCompletedInfo extends  Object
+    {
+        private final boolean result;
+        private final long timeMillis, atElapsedMillis, durationMillis;
+        public BootCompletedInfo(long timeMillis, long atElapsedMillis, long durationMillis, boolean result) {
+            this.timeMillis = timeMillis;
+            this.atElapsedMillis = atElapsedMillis;
+            this.durationMillis = durationMillis;
+            this.result = result;
+        }
+        public long getTimeMillis() {
+            return timeMillis;
+        }
+        public long getAtElapsedMillis() {
+            return atElapsedMillis;
+        }
+        public long getDurationMillis() {
+            return durationMillis;
+        }
+        public boolean getResult() {
+            return result;
+        }
+    }
+
+    public static BootCompletedInfo loadPrefLastBootCompleted(Context context)
+    {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return new BootCompletedInfo(prefs.getLong(PREF_KEY_ALARM_BOOTCOMPLETED, -1),
+                prefs.getLong(PREF_KEY_ALARM_BOOTCOMPLETED_ATELAPSED, -1),
+                prefs.getLong(PREF_KEY_ALARM_BOOTCOMPLETED_DURATION, -1),
+                prefs.getBoolean(PREF_KEY_ALARM_BOOTCOMPLETED_RESULT, false));
+    }
+    public static void savePrefLastBootCompleted(Context context, BootCompletedInfo info) {
+        savePrefLastBootCompleted(context, new BootCompletedInfo(info.getTimeMillis(), info.getAtElapsedMillis(), info.getDurationMillis(), info.getResult()));
+    }
+    public static void savePrefLastBootCompleted(Context context, long timeMillis, long atElapsedMillis, long durationMillis) {
+        SharedPreferences.Editor prefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        prefs.putLong(PREF_KEY_ALARM_BOOTCOMPLETED, timeMillis);
+        prefs.putLong(PREF_KEY_ALARM_BOOTCOMPLETED_ATELAPSED, atElapsedMillis);
+        prefs.putLong(PREF_KEY_ALARM_BOOTCOMPLETED_DURATION, durationMillis);
+        prefs.putBoolean(PREF_KEY_ALARM_BOOTCOMPLETED_RESULT, true);
+        prefs.apply();
+    }
+    public static void savePrefLastBootCompleted_started(Context context, long atElapsedMillis)
+    {
+        SharedPreferences.Editor prefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        prefs.putLong(PREF_KEY_ALARM_BOOTCOMPLETED_ATELAPSED, atElapsedMillis);
+        prefs.putBoolean(PREF_KEY_ALARM_BOOTCOMPLETED_RESULT, false);
+        prefs.apply();
+    }
+    public static void savePrefLastBootCompleted_finished(Context context, long timeMillis, long durationMillis)
+    {
+        SharedPreferences.Editor prefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        prefs.putLong(PREF_KEY_ALARM_BOOTCOMPLETED, timeMillis);
+        prefs.putLong(PREF_KEY_ALARM_BOOTCOMPLETED_DURATION, durationMillis);
+        prefs.putBoolean(PREF_KEY_ALARM_BOOTCOMPLETED_RESULT, true);
+        prefs.apply();
+    }
+
+    public static boolean bootCompletedWasRun(Context context)
+    {
+        BootCompletedInfo info = loadPrefLastBootCompleted(context);
+        return (info.getTimeMillis() >= timeOfLastBoot());
+    }
+    public static long timeOfLastBoot() {
+        return System.currentTimeMillis() - SystemClock.elapsedRealtime();
     }
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmClockActivity.java
@@ -262,7 +262,7 @@ public class AlarmClockActivity extends AppCompatActivity
                     if (data != null)
                     {
                         long alarmID = ContentUris.parseId(data);
-                        list.reloadAdapter(alarmID);
+                        list.reloadAdapter((alarmID != -1 ? alarmID : null));
                         Log.d("DEBUG", "adapter reloaded: " + alarmID);
 
                     } else Log.e(TAG, "updateReceiver.onReceive: null data!");
@@ -926,6 +926,12 @@ public class AlarmClockActivity extends AppCompatActivity
     }
     private void checkWarnings()
     {
+        if (!AlarmSettings.bootCompletedWasRun(this))
+        {
+            Log.w(TAG, "checkWarnings: BOOT_COMPLETED hasn't run yet! triggering it now..");
+            sendBroadcast(new Intent(AlarmNotifications.getAlarmIntent(this, AlarmNotifications.ACTION_SCHEDULE, null)));
+        }
+
         notificationWarning.setShouldShow(!NotificationManagerCompat.from(this).areNotificationsEnabled());
         if (batteryOptimizationWarning != null) {
             batteryOptimizationWarning.setShouldShow(!AlarmSettings.isIgnoringBatteryOptimizations(this));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -892,6 +892,7 @@
     <string name="configLabel_alarms_bootcompleted_info">Last run on <xliff:g id="timestamp" example="never">%1$s</xliff:g>,\n<xliff:g id="time" example="30s">%2$s</xliff:g> after boot (took <xliff:g id="time" example="10s">%3$s</xliff:g>).</string>      <!-- TODO -->
     <string name="configLabel_alarms_bootcompleted_info_never">Never</string>   <!-- TODO -->
     <string name="configLabel_alarms_bootcompleted_action_confirm">Reschedule all alarms and notifications?</string>   <!-- TODO -->
+    <string name="configLabel_alarms_bootcompleted_action_message">Rescheduling alarms and notifications..</string>   <!-- TODO -->
 
     <!-- TODO: fix displaying comments in "..._summary" strings (text around %s) (MillisecondPickerPreference) -->
     <string name="configLabel_alarms_silenceAfter">Go silent after</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -887,6 +887,12 @@
     <string name="configLabel_alarms_notifications_summary1">On lock screen: %1$s</string>    <!-- "On lock screen: Off -->
     <string name="notificationsWarning"><xliff:g id="warningTag">[w]</xliff:g> Notifications are off. Alarms may fail to display correctly.</string>  <!-- snackbar message -->
 
+    <string name="configLabel_alarms_bootcompleted">Boot Completed</string>   <!-- TODO -->
+    <string name="configLabel_alarms_bootcompleted_summary">Alarms are automatically rescheduled a few minutes after reboot.\n\n<xliff:g id="_info" example="last run: never">%1$s</xliff:g></string>      <!-- TODO -->
+    <string name="configLabel_alarms_bootcompleted_info">Last run on <xliff:g id="timestamp" example="never">%1$s</xliff:g>,\n<xliff:g id="time" example="30s">%2$s</xliff:g> after boot (took <xliff:g id="time" example="10s">%3$s</xliff:g>).</string>      <!-- TODO -->
+    <string name="configLabel_alarms_bootcompleted_info_never">Never</string>   <!-- TODO -->
+    <string name="configLabel_alarms_bootcompleted_action_confirm">Reschedule all alarms and notifications?</string>   <!-- TODO -->
+
     <!-- TODO: fix displaying comments in "..._summary" strings (text around %s) (MillisecondPickerPreference) -->
     <string name="configLabel_alarms_silenceAfter">Go silent after</string>
     <string name="configLabel_alarms_silenceAfter_summary"><xliff:g id="timePeriod" example="10 minutes">%s</xliff:g></string>

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -97,6 +97,12 @@
             android:summary="@string/dialog_msg_donotshowagain"
             android:defaultValue="false" />
 
+        <Preference
+            android:key="app_alarms_bootcompleted"
+            android:title="@string/configLabel_alarms_bootcompleted"
+            android:summary="@string/configLabel_alarms_bootcompleted_summary"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -71,6 +71,12 @@
             android:summary="@string/dialog_msg_donotshowagain"
             android:defaultValue="false" />
 
+        <Preference
+            android:key="app_alarms_bootcompleted"
+            android:title="@string/configLabel_alarms_bootcompleted"
+            android:summary="@string/configLabel_alarms_bootcompleted_summary"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
* SuntimesAlarms activity now reschedules all alarms if `boot_completed` has failed to run.
* AlarmNotificationService now reschedules all alarms after app upgrades (`android.intent.action.ACTION_MY_PACKAGE_REPLACED` broadcast).
* adds a foreground service notification while rescheduling all alarms (shown during `boot_completed`, and `timezone_changed`).
* adds "Boot Completed" to the Alarm Settings; shows reboot information and manually triggers "reschedule all".
* AlarmNotificationService `onScheduled_*` events now broadcast `update_ui` (forces running apps to update their UI).

