### PR TITLE
release v0.14.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,23 @@
 ### ~
 
-### v0.14.11 (2022-11-23)
+### v0.14.11 (2022-11-29)
 * adds permission REQUEST_IGNORE_BATTERY_OPTIMIZATIONS (#651) [PERMISSION]; SuntimesAlarms now makes a direct request to be added to the whitelist.
 * adds a help dialog that explains battery optimization warnings; adds online help; a revised message is shown for devices that are likely to break alarms.
 * adds data substitutions `eot` (formatted equation of time), and `eot_m` (equation of time millis) (#649).
 * adds "Boot Completed" to the Alarm Settings; shows reboot information and manually triggers "reschedule all" (#653).
 * adds a foreground service notification that is shown while rescheduling all alarms (#653).
 * changes SuntimesAlarms to reschedule all alarms after an app upgrade (ACTION_MY_PACKAGE_REPLACED), or if it detects that boot_completed has failed to run.
+* adds `suntimes.action.widgets.UPDATE_ALL` to SuntimesActivity (#649); causes app launch to also trigger a widget update.
+* adds `OPEN_SETTINGS` to widget actions; enhances the action editor with Suntimes specific action suggestions.
 * fixes bug 'alarm list shows stale values when opened immediately after reboot' (#647).
-* fixes bug 'unable to disable alarm reminder notification' (#650).
+* fixes bug 'unable to disable alarm reminder notification' (#650); adds 'never' button to preference dialog; notification can now be dismissed by swiping.
+* fixes bug in LocationDialog where the spinner is blank after canceling PlacesActivity request.
+* fixes bug in LocationDialog where location request doesn't automatically start after granting permissions.
+* fixes crash in LocationDialog when clicking "Use last position".
+* miscellaneous 2x1 sun widget fixes; scale text/icons, centers layout (#423).
 * updates translation to Norwegian (nb) (#648 by FTno).
-* updates translation to Traditional Chinese (zh_TW) (#646 by James Liu).
-* updates translation to Simplified Chinese (zh_CN) (#645 by sr093906, #646 by James Liu).
+* updates translation to Traditional Chinese (zh_TW) (#646, #657 by James Liu).
+* updates translation to Simplified Chinese (zh_CN) (#645 by sr093906, #646, #657 by James Liu).
 
 ### v0.14.10 (2022-11-08)
 * adds "abbreviated month names" widget option (#625).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### ~
 
+### v0.14.11 (2022-11-23)
+* adds permission REQUEST_IGNORE_BATTERY_OPTIMIZATIONS (#651) [PERMISSION]; SuntimesAlarms now makes a direct request to be added to the whitelist.
+* adds a help dialog that explains battery optimization warnings; adds online help; a revised message is shown for devices that are likely to break alarms.
+* adds data substitutions `eot` (formatted equation of time), and `eot_m` (equation of time millis) (#649).
+* adds "Boot Completed" to the Alarm Settings; shows reboot information and manually triggers "reschedule all" (#653).
+* adds a foreground service notification that is shown while rescheduling all alarms (#653).
+* changes SuntimesAlarms to reschedule all alarms after an app upgrade (ACTION_MY_PACKAGE_REPLACED), or if it detects that boot_completed has failed to run.
+* fixes bug 'alarm list shows stale values when opened immediately after reboot' (#647).
+* fixes bug 'unable to disable alarm reminder notification' (#650).
+* updates translation to Norwegian (nb) (#648 by FTno).
+* updates translation to Traditional Chinese (zh_TW) (#646 by James Liu).
+* updates translation to Simplified Chinese (zh_CN) (#645 by sr093906, #646 by James Liu).
+
 ### v0.14.10 (2022-11-08)
 * adds "abbreviated month names" widget option (#625).
 * adds a help dialog to the alarm edit activity (#628); adds "day light saving" to main help dialog.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 94
-        versionName "0.14.10"
+        versionCode 95
+        versionName "0.14.11"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/95.txt
+++ b/fastlane/metadata/android/en-US/changelogs/95.txt
@@ -1,0 +1,3 @@
+- miscellaneous alarm bug fixes and reliability improvements.
+- updates translations to Simplified Chinese, and Traditional Chinese.
+- updates translation to Norwegian.


### PR DESCRIPTION
* adds permission REQUEST_IGNORE_BATTERY_OPTIMIZATIONS (#651) [PERMISSION]; SuntimesAlarms now makes a direct request to be added to the whitelist.
* adds a help dialog that explains battery optimization warnings; adds online help; a revised message is shown for devices that are likely to break alarms.
* adds data substitutions `eot` (formatted equation of time), and `eot_m` (equation of time millis) (#649).
* adds "Boot Completed" to the Alarm Settings; shows reboot information and manually triggers "reschedule all" (#653).
* adds a foreground service notification that is shown while rescheduling all alarms (#653).
* changes SuntimesAlarms to reschedule all alarms after an app upgrade (ACTION_MY_PACKAGE_REPLACED), or if it detects that boot_completed has failed to run.
* adds `suntimes.action.widgets.UPDATE_ALL` to SuntimesActivity (closes #649); causes app launch to also trigger a widget update.
* adds `OPEN_SETTINGS` to widget actions; enhances the action editor with Suntimes specific action suggestions.
* fixes bug 'alarm list shows stale values when opened immediately after reboot' (closes #647).
* fixes bug 'unable to disable alarm reminder notification' (closes #650); adds 'never' button to preference dialog; notification can now be dismissed by swiping.
* fixes bug in LocationDialog where the spinner is blank after canceling PlacesActivity request.
* fixes bug in LocationDialog where location request doesn't automatically start after granting permissions.
* fixes crash in LocationDialog when clicking "Use last position".
* miscellaneous 2x1 sun widget fixes; scale text/icons, centers layout (closes #423).
* updates translation to Norwegian (nb) (#648 by FTno).
* updates translation to Traditional Chinese (zh_TW) (#646, #657 by James Liu).
* updates translation to Simplified Chinese (zh_CN) (#645 by sr093906, #646, #657 by James Liu).