### PR TITLE
release 0.14.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.14.12 (2022-12-21)
+### v0.14.12 (2022-12-22)
 * adds a boot notification if battery optimization is enabled (and alarms are active).
 * fixes bug "dismiss alarm fails to remove alarm notification" (#665).
 * fixes bug when re-scheduling repeating moon phase alarms (#494; "unreliable full moon alarm").

--- a/app/src/main/res/drawable-v23/toast_frame.xml
+++ b/app/src/main/res/drawable-v23/toast_frame.xml
@@ -1,0 +1,20 @@
+<!--/* Copyright 2017, The Android Open Source Project
+    **
+    ** Licensed under the Apache License, Version 2.0 (the "License");
+    ** you may not use this file except in compliance with the License.
+    ** You may obtain a copy of the License at
+    **
+    **     http://www.apache.org/licenses/LICENSE-2.0
+    **
+    ** Unless required by applicable law or agreed to in writing, software
+    ** distributed under the License is distributed on an "AS IS" BASIS,
+    ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    ** See the License for the specific language governing permissions and
+    ** limitations under the License.
+    */
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?android:attr/colorBackgroundFloating" />
+    <corners android:radius="28dp" />
+</shape>

--- a/app/src/main/res/drawable/toast_frame.xml
+++ b/app/src/main/res/drawable/toast_frame.xml
@@ -1,20 +1,4 @@
-<!--/* Copyright 2017, The Android Open Source Project
-    **
-    ** Licensed under the Apache License, Version 2.0 (the "License");
-    ** you may not use this file except in compliance with the License.
-    ** You may obtain a copy of the License at
-    **
-    **     http://www.apache.org/licenses/LICENSE-2.0
-    **
-    ** Unless required by applicable law or agreed to in writing, software
-    ** distributed under the License is distributed on an "AS IS" BASIS,
-    ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    ** See the License for the specific language governing permissions and
-    ** limitations under the License.
-    */
--->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="?android:attr/colorBackgroundFloating" />
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#5A595B" />
     <corners android:radius="28dp" />
 </shape>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -16,4 +16,10 @@
         <item name="icActionPrevious">@drawable/ic_action_previous_item</item>
         <item name="android:windowContentTransitions">true</item>
     </style>
+
+    <style name="ToastTextAppearance">
+        <item name="android:textColor">?android:attr/textColorPrimary</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:fontFamily">sans-serif</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -661,6 +661,5 @@
     <style name="ToastTextAppearance">
         <item name="android:textColor">?android:attr/textColorPrimary</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:fontFamily">sans-serif</item>
     </style>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Sat May 27 21:16:52 MST 2017
-#org.gradle.jvmargs=-Xmx256m
+org.gradle.jvmargs=-Xmx2048m
+


### PR DESCRIPTION
* adds a boot "warning notification" if battery optimization is enabled (and alarms are active).
* fixes bug "dismissing alarm fails to remove alarm notification" (closes #665).
* fixes bug when re-scheduling repeating moon phase alarms (#494; "unreliable full moon alarm").
* fixes bug where toast messages are unreadable when using system dark mode (white text on a white background) (Android 12) (closes #660).
* fixes bug in AlarmEditActivity where the UI fails to display the configured label.
* fixes bug "alarm reminder is not shown after changing 'reminder within' setting" (closes #659).
* fixes potential NPE in AlarmNotifications `updateAlarmTime_` methods when repeatingDays is null.
* fixes potential NPE in AlarmEditActivity when alarm location is null.
* fixes potential NPE in AlarmAddons when addon event pickers supply an invalid uri (missing provider, missing permissions).