### PR TITLE
release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * fixes bug "widgets crash with lawnchair2" (#690).
 * fixes bug where the main table header displays azimuth at civil twilight instead of sunrise/sunset.
 * fixes bug where scaled text is cropped in 1x1 moon widget and 1x1 date widget.
+* updates translation to Norwegian (nb) (#693 by FTno).
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#688 by James Liu).
 
 ### v0.15.0 (2023-01-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### ~
 
+### v0.15.1 (2023-02-14)
+* adds Chinese, Indian, Japanese, Korean, Minguo, and Vietnamese calendars to the date widget (#692).
+* adds %eZ@ (azimuth), %eD@ (declination), and %eR@ (right ascension) title substitutions (#677).
+* fixes bug "app crash when showing moon dialog from shortcut" (#691).
+* fixes bug "widgets crash with lawnchair2" (#690).
+* fixes bug where the main table header displays azimuth at civil twilight instead of sunrise/sunset.
+* fixes bug where scaled text is cropped in 1x1 moon widget and 1x1 date widget.
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#688 by James Liu).
+
 ### v0.15.0 (2023-01-31)
 * adds "Welcome Dialog"; a guided introduction and initial configuration wizard (#603).
 * adds "High Contrast" app themes (#492, #615); changes default theme to "System default" (#666).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ### ~
 
-### v0.15.1 (2023-02-14)
+### v0.15.1 (2023-02-15)
+* adds themed icon (Android 13+).
 * adds Chinese, Indian, Japanese, Korean, Minguo, and Vietnamese calendars to the date widget (#692).
 * adds %eZ@ (azimuth), %eD@ (declination), and %eR@ (right ascension) title substitutions (#677).
 * fixes bug "app crash when showing moon dialog from shortcut" (#691).
-* fixes bug "widgets crash with lawnchair2" (#690).
+* fixes bug "widgets crash with Lawnchair" (#690).
+* fixes bug "navigation bar is white instead of black with dark theme" (#696).
 * fixes bug where the main table header displays azimuth at civil twilight instead of sunrise/sunset.
 * fixes bug where scaled text is cropped in 1x1 moon widget and 1x1 date widget.
 * updates translation to Norwegian (nb) (#693 by FTno).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Widgets are resizable and include...
 * 1x1 digital clock widget that displays solar time (or a given timezone).
 
 **Date widgets:**
-* 1x1 date widget that displays the date with a given calendars (Coptic, Ethiopian, Gregorian, Hebrew, Julian, Solar Hijiri, or Thai Solar).
+* 1x1 date widget that displays the date with a given calendars (Chinese, Coptic, Ethiopian, Gregorian, Hebrew, Indian, Japanese, Julian, Korean, Minguo, Solar Hijiri, Thai Solar, or Vietnamese).
 
 **Sun widgets:**
 * 1x1 sun widget that displays the sunrise or sunset time.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 97
-        versionName "0.15.0"
+        versionCode 98
+        versionName "0.15.1"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/98.txt
+++ b/fastlane/metadata/android/en-US/changelogs/98.txt
@@ -1,0 +1,5 @@
+- adds Indian, Japanese, and Minguo calendars to the date widget.
+- adds Chinese, Korean, and Vietnamese lunisolar calendars.
+- fixes bug "widget crashes with lawnchair2" (#690).
+- fixes bug "app crash when showing moon dialog from shortcut" (#691).
+- updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/98.txt
+++ b/fastlane/metadata/android/en-US/changelogs/98.txt
@@ -2,4 +2,5 @@
 - adds Chinese, Korean, and Vietnamese lunisolar calendars.
 - fixes bug "widget crashes with lawnchair2" (#690).
 - fixes bug "app crash when showing moon dialog from shortcut" (#691).
+- updates translation to Norwegian.
 - updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/98.txt
+++ b/fastlane/metadata/android/en-US/changelogs/98.txt
@@ -1,6 +1,6 @@
-- adds Indian, Japanese, and Minguo calendars to the date widget.
-- adds Chinese, Korean, and Vietnamese lunisolar calendars.
-- fixes bug "widget crashes with lawnchair2" (#690).
+- adds themed icon (Android 13).
+- adds calendars to the date widget.
+- fixes bug "widgets crash with Lawnchair" (#690).
 - fixes bug "app crash when showing moon dialog from shortcut" (#691).
 - updates translation to Norwegian.
 - updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* adds themed icon (Android 13+).
* adds Chinese, Indian, Japanese, Korean, Minguo, and Vietnamese calendars to the date widget (closes #692).
* adds %eZ@ (azimuth), %eD@ (declination), and %eR@ (right ascension) title substitutions (#677).
* fixes bug "app crash when showing moon dialog from shortcut" (closes #691).
* fixes bug "widgets crash with lawnchair2" (closes #689, closes #690).
* fixes bug "navigation bar is white instead of black with dark theme" (closes #696).
* fixes bug where the main table header displays azimuth at civil twilight instead of sunrise/sunset.
* fixes bug where scaled text is cropped in 1x1 moon widget and 1x1 date widget.
* updates translation to Norwegian (nb) (#693 by FTno).
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#688 by James Liu).