### PR TITLE
release 0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### ~
 
+### v0.15.5 (2023-07-01)
+* adds Hijri calendar to the date widget (#714).
+* fixes bug where alarms using Apparent Solar Time drift over time (#715).
+* fixes bug where app dialogs display Apparent Solar Time with reduced accuracy.
+* fixes bug where actions fail to apply all available %substitutions.
+* fixes bug where actions fail to apply the correct `extra type` to %substitutions.
+* increases max snooze from 59 to 120 minutes; increases max "auto dismiss" from 59 to 300 seconds.
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#716 by James Liu).
+
 ### v0.15.4 (2023-06-03)
 * adds support for Android TV.
 * adds "current location" mode to widgets (#707); widgets use the "last known" location from any provider.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 101
-        versionName "0.15.4"
+        versionCode 102
+        versionName "0.15.5"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/102.txt
+++ b/fastlane/metadata/android/en-US/changelogs/102.txt
@@ -1,0 +1,4 @@
+- adds Hijri calendar to the date widget (#714).
+- fixes bug where "Apparent Solar Time" alarms drift over time (#715).
+- fixes bug where dialogs display "Apparent Solar Time" with reduced accuracy.
+- fixes bugs when using %substitutions with widget actions.


### PR DESCRIPTION
* adds Hijri calendar to the date widget (closes #714).
* fixes bug where alarms using Apparent Solar Time drift over time (closes #715).
* fixes bug where app dialogs display Apparent Solar Time with reduced accuracy.
* fixes bug where actions fail to apply all available %substitutions.
* fixes bug where actions fail to apply the correct `extra type` to %substitutions.
* increases max snooze from 59 to 120 minutes; increases max "auto dismiss" from 59 to 300 seconds.
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#716 by James Liu).