### PR TITLE
release 0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ### ~
 
-### v0.15.6 (2023-07-17)
+### v0.15.6 (2023-07-21)
 * improves time zone defaults (localized default values).
 * improves time zone recommendations; fixes recommendation when place names contain spaces or special characters.
 * adds "recommend time zone" action to time zone dialog.
 * fixes time zone list to show the correct display name and offset when day light saving is applied.
 * fixes app crash when addons attempt to open settings with an invalid fragment.
 * changes labels for cross-quarter days (#719); Imbolc, Beltane, Lughnasadh, Samhain.
+* changes snooze notification so that it no longer triggers fullscreen intent (#724).
 * updates translation to Polish and Esperanto (eo, pl) (#722 by Verdulo).
 * updates translation to Brazilian Portuguese (pt-br) (#721 by naoliv).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### ~
 
+### v0.15.6 (2023-07-17)
+* improves time zone defaults (localized default values).
+* improves time zone recommendations; fixes recommendation when place names contain spaces or special characters.
+* adds "recommend time zone" action to time zone dialog.
+* fixes time zone list to show the correct display name and offset when day light saving is applied.
+* fixes app crash when addons attempt to open settings with an invalid fragment.
+* changes labels for cross-quarter days (#719); Imbolc, Beltane, Lughnasadh, Samhain.
+* updates translation to Polish and Esperanto (eo, pl) (#722 by Verdulo).
+* updates translation to Brazilian Portuguese (pt-br) (#721 by naoliv).
+
 ### v0.15.5 (2023-07-01)
 * adds Hijri calendar to the date widget (#714).
 * fixes bug where alarms using Apparent Solar Time drift over time (#715).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 102
-        versionName "0.15.5"
+        versionCode 103
+        versionName "0.15.6"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/103.txt
+++ b/fastlane/metadata/android/en-US/changelogs/103.txt
@@ -1,0 +1,4 @@
+- improves time zone defaults, and time zone recommendations.
+- changes labels for cross-quarter days; Imbolc, Beltane, Lughnasadh, Samhain.
+- updates translation to Polish and Esperanto.
+- updates translation to Brazilian Portuguese,

--- a/fastlane/metadata/android/en-US/changelogs/103.txt
+++ b/fastlane/metadata/android/en-US/changelogs/103.txt
@@ -1,4 +1,4 @@
 - improves time zone defaults, and time zone recommendations.
 - changes labels for cross-quarter days; Imbolc, Beltane, Lughnasadh, Samhain.
 - updates translation to Polish and Esperanto.
-- updates translation to Brazilian Portuguese,
+- updates translation to Brazilian Portuguese.


### PR DESCRIPTION
* improves time zone defaults (localized default values).
* improves time zone recommendations; fixes recommendation when place names contain spaces or special characters.
* adds "recommend time zone" action to time zone dialog.
* fixes time zone list to show the correct display name and offset when day light saving is applied.
* fixes app crash when addons attempt to open settings with an invalid fragment.
* changes labels for cross-quarter days (#719); Imbolc, Beltane, Lughnasadh, Samhain.
* updates translation to Polish and Esperanto (eo, pl) (#722 by Verdulo).
* updates translation to Brazilian Portuguese (pt-br) (#721 by naoliv).