### PR TITLE
release 0.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ### ~
 
-### v0.15.7 (2023-09-05)
+### v0.15.7 (2023-09-10)
 * adds a warning to SuntimesAlarms when the "Autostart" setting is disabled (Xiomi devices only) (#730).
-* fixes bugs where rapidly clicking triggers an action more than once (throttled click listeners).
+* fixes bug "time refreshes aren't happening properly" (#705).
+* fixes bug where the update loop continues running in the background after the activity is no longer visible.
+* fixes bugs where rapidly clicking triggers actions more than once (throttled click listeners).
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#728 by James Liu).
 
 ### v0.15.6 (2023-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.15.7 (2023-09-05)
+* adds a warning to SuntimesAlarms when the "Autostart" setting is disabled (Xiomi devices only) (#730).
+* fixes bugs where rapidly clicking triggers an action more than once (throttled click listeners).
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#728 by James Liu).
+
 ### v0.15.6 (2023-07-21)
 * improves time zone defaults (localized default values).
 * improves time zone recommendations; fixes recommendation when place names contain spaces or special characters.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 103
-        versionName "0.15.6"
+        versionCode 104
+        versionName "0.15.7"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/104.txt
+++ b/fastlane/metadata/android/en-US/changelogs/104.txt
@@ -1,2 +1,3 @@
 - adds a warning to SuntimesAlarms when the "Autostart" setting is disabled (Xiomi devices only).
+- fixes bug "time refreshes aren't happening properly" (#705).
 - updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/104.txt
+++ b/fastlane/metadata/android/en-US/changelogs/104.txt
@@ -1,0 +1,2 @@
+- adds a warning to SuntimesAlarms when the "Autostart" setting is disabled (Xiomi devices only).
+- updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* adds a warning to SuntimesAlarms when the "Autostart" setting is disabled (Xiomi devices only) (closes #730).
* fixes bug "time refreshes aren't happening properly" (closes #705).
* fixes bug where the update loop continues running in the background after the activity is no longer visible.
* fixes bugs where rapidly clicking triggers actions more than once (throttled click listeners).
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#728 by James Liu).