### PR TITLE
release 0.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### ~
 
+### v0.15.8 (2023-10-23)
+* adds a warning when the app is configured to "current location" but location permissions are denied (#733).
+* changes the location label when switching away from "current location" mode (#733).
+* fixes a bug in "current location" mode; the location automatically refreshes when the activity is resumed (#733).
+* fixes a bug where the time zone selector shows the wrong system time zone (#733).
+* fixes a bug where the alarm event icon and text are out of alignment.
+* refactors alarm click listeners to pass rowID instead of position; fixes potential bugs if items are re-ordered.
+* moves each widget and tile configuration activity into its own task (separate back stacks).
+* updates translation to Hungarian (hu) (#736 by titanicbobo).
+
 ### v0.15.7 (2023-09-10)
 * adds a warning to SuntimesAlarms when the "Autostart" setting is disabled (Xiomi devices only) (#730).
 * fixes bug "time refreshes aren't happening properly" (#705).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 ### ~
 
-### v0.15.8 (2023-10-23)
+### v0.15.8 (2023-10-24)
 * adds a warning when the app is configured to "current location" but location permissions are denied (#733).
 * changes the location label when switching away from "current location" mode (#733).
-* fixes a bug in "current location" mode; the location automatically refreshes when the activity is resumed (#733).
-* fixes a bug where the time zone selector shows the wrong system time zone (#733).
-* fixes a bug where the alarm event icon and text are out of alignment.
-* refactors alarm click listeners to pass rowID instead of position; fixes potential bugs if items are re-ordered.
-* moves each widget and tile configuration activity into its own task (separate back stacks).
+* fixes bug in "current location" mode; the location automatically refreshes when the activity is resumed (#733).
+* fixes bug where the time zone selector shows the wrong system time zone (#733).
+* fixes bug where the alarm event icon and text are out of alignment.
+* refactors alarm adapter click listeners (bind rowID instead of position).
 * updates translation to Hungarian (hu) (#736 by titanicbobo).
 
 ### v0.15.7 (2023-09-10)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 104
-        versionName "0.15.7"
+        versionCode 105
+        versionName "0.15.8"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/105.txt
+++ b/fastlane/metadata/android/en-US/changelogs/105.txt
@@ -1,0 +1,3 @@
+- fixes bugs in "current location" mode (automatically refresh the location).
+- adds a warning when using "current location" but permissions are denied.
+- updates translation to Hungarian.

--- a/fastlane/metadata/android/en-US/changelogs/105.txt
+++ b/fastlane/metadata/android/en-US/changelogs/105.txt
@@ -1,3 +1,3 @@
 - fixes bugs in "current location" mode (automatically refresh the location).
-- adds a warning when using "current location" but permissions are denied.
+- adds a warning when using "current location" but location permissions are denied.
 - updates translation to Hungarian.


### PR DESCRIPTION
* adds a warning when the app is configured to "current location" but location permissions are denied (#733).
* changes the location label when switching away from "current location" mode (#733).
* fixes a bug in "current location" mode; the location automatically refreshes when the activity is resumed (closes #733).
* fixes a bug where the time zone selector shows the wrong system time zone (closes #733).
* fixes a bug where the alarm event icon and text are out of alignment.
* refactors alarm adapter click listeners (bind rowID instead of position).
* updates translation to Hungarian (hu) (#736 by titanicbobo) (#670).