### PR TITLE
release 0.15.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.15.9 (2023-11-29)
+* fixes navigation bugs when using D-pad (Android TV).
+* fixes app crash after changing `data source` (#743).
+* fixes bug where toolbar fails to apply text size setting.
+* fixes bug where alarm dismiss challenge is shown after alarm has timed-out.
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#745 by James Liu).
+
 ### v0.15.8 (2023-10-24)
 * adds a warning when the app is configured to "current location" but location permissions are denied (#733).
 * changes the location label when switching away from "current location" mode (#733).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 105
-        versionName "0.15.8"
+        versionCode 106
+        versionName "0.15.9"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/106.txt
+++ b/fastlane/metadata/android/en-US/changelogs/106.txt
@@ -1,0 +1,2 @@
+- fixes navigation bugs when using D-pad (Android TV).
+- updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* fixes navigation bugs when using D-pad (Android TV).
* fixes app crash after changing `data source` (closes #743).
* fixes bug where toolbar fails to apply text size setting.
* fixes bug where alarm dismiss challenge is shown after alarm has timed-out.
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#745 by James Liu).