### PR TITLE
release 0.15.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### ~
 
 ### v0.15.10 (2023-12-31)
+* fixes app crash when tapping on the date (#751).
 * fixes bug where the solstice widget displays "cross-quarter days" when disabled by the app (#755).
 * increments `CalculatorProviderContract` version 5 -> 6; fixes columns for "cross-quarter days".
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#752 by James Liu).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.15.10 (2023-12-31)
+* fixes bug where the solstice widget displays "cross-quarter days" when disabled by the app (#755).
+* increments `CalculatorProviderContract` version 5 -> 6; fixes columns for "cross-quarter days".
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#752 by James Liu).
+
 ### v0.15.9 (2023-12-03)
 * adds a `back` button to the alarm dismiss activity (#750).
 * fixes navigation bugs when using D-pad (Android TV).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ### ~
 
-### v0.15.10 (2023-12-31)
-* fixes app crash when tapping on the date (#751).
+### v0.15.10 (2024-01-14)
+* adds layouts and resources for very small screens (#727); experimental support for wearables.
+* adds 'columns' setting to moon dialog; 2, 3 or 4 columns.
+* fixes app crash when tapping on the date field (#751).
+* fixes bug "can't interact with app after install (flashes/strobes)" (#760).
+* fixes bug "custom date format is not saved"; adds calendar format pattern "EE, MMM d" (#759).
 * fixes bug where the solstice widget displays "cross-quarter days" when disabled by the app (#755).
+* fixes bug where moon dialog content is clipped (#754).
 * increments `CalculatorProviderContract` version 5 -> 6; fixes columns for "cross-quarter days".
+* changes "header labels" default to "none" for translations with longer strings (de, fr, hu, nb, nl, pt_BR) (#754).
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#752 by James Liu).
 
 ### v0.15.9 (2023-12-03)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ When reporting a bug **please be detailed as possible**. What did you expect the
 
 ## Legal Stuff
 
-Copyright &#169; 2014-2023 Forrest Guice<br/>
+Copyright &#169; 2014-2024 Forrest Guice<br/>
 
 The source code is available under [GPLv3](LICENSE) (https://github.com/forrestguice/SuntimesWidget).
 > This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the [GNU General Public License](LICENSE) for more details.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 106
-        versionName "0.15.9"
+        versionCode 107
+        versionName "0.15.10"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1663,7 +1663,7 @@
     ]]></string>
     <string name="app_legal1"><![CDATA[
     <b>Codi font:</b><br />
-    Copyright &#169 2014-2023 Forrest Guice <br />
+    Copyright &#169 2014-2024 Forrest Guice <br />
     Codi font disponible sota GPLv3.
 ]]></string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1777,7 +1777,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Zdrojový kód:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Zdorjový kód dostupný pod licencí GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1650,7 +1650,7 @@
       <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> um eine Anfrage zu stellen.
   ]]></string>
   <string name="app_legal1"><![CDATA[
-      Copyright &#169 2014-2023 Forrest Guice <br />
+      Copyright &#169 2014-2024 Forrest Guice <br />
       Quellcode verf&uuml;gbar unter GPLv3.
   ]]></string>
 

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -1641,7 +1641,7 @@
     ]]></string>
     <string name="app_license_about">La aplikaĵo Suntempoj estas libera kaj malfermkoda programaro.</string>   <!-- displayed by welcome dialog -->-->
     <string name="app_legal1"><![CDATA[
-        Aŭtorrajto &#169 2014-2023 Forrest GUICE <br />
+        Aŭtorrajto &#169 2014-2024 Forrest GUICE <br />
         Fontkodo disponebla laŭ la permesilo GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1651,7 +1651,7 @@
 ]]></string>
     <string name="app_legal1"><![CDATA[
     <b>Código fuente:</b> <br />
-    Copyright &#169 2014-2023 Forrest Guice <br />
+    Copyright &#169 2014-2024 Forrest Guice <br />
     Código fuente disponible bajo GPLv3.
 ]]></string>
 

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -1677,7 +1677,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Iturburu kodea:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Iturburu kodea GPLv3 lizentziapean eskuragarri dago.
     ]]></string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1638,7 +1638,7 @@
     ]]></string>
     <string name="app_legal1"><![CDATA[
         <b>Code source :</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Code source disponible sous licence GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1642,7 +1642,7 @@
     ]]></string>
     <string name="app_legal1"><![CDATA[
         <b>Forráskód:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         A forráskód elérhető a GPLv3 alatt.
     ]]></string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1683,7 +1683,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Codice sorgente:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Codice sorgente disponibile con licenza GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1666,7 +1666,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Kildekode:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Source code available under GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1759,7 +1759,7 @@
     ]]></xliff:g></string>-->
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />
-        Copyright &#169 2014-2022 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Source code available under GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1662,7 +1662,7 @@
     <string name="app_shortdesc">Wyświetla czasy świecenia Słońca i Księżyca.</string>
     <string name="app_support_url"><![CDATA[<b>Wsparcie:</b> odwiedź <a href="https://github.com/forrestguice/SuntimesWidget/issues">stronę trackera błędów</a> aby zgłosić błąd/sugestię.]]></string>
     <string name="app_license_about">Aplikacja Czasy Słońca jest wolnym i otwartoźródłowym oprogramowaniem.</string>   <!-- displayed by welcome dialog -->-->
-    <string name="app_legal1"><![CDATA[Prawo autorskie &#169 2014–2022 Forrest Guice <br />Kod źródłowy dostępny na licencji GPLv3.]]></string>
+    <string name="app_legal1"><![CDATA[Prawo autorskie &#169 2014–2024 Forrest Guice <br />Kod źródłowy dostępny na licencji GPLv3.]]></string>
 
     <string name="app_legal2"><![CDATA[<b>Tłumaczenia na:</b><br/>]]><xliff:g id="locale_credits">%1$s</xliff:g></string>
     <string name="translationCreditsFormat"><![CDATA[&#8226;&nbsp;<b><xliff:g id="languageName">%1$s</xliff:g></b>: <xliff:g id="authorList">%2$s</xliff:g>.]]></string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1718,7 +1718,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Código Aberto:</b><br />
-        Direitos Reservados a &#169 2014-2023 Forrest Guice <br />
+        Direitos Reservados a &#169 2014-2024 Forrest Guice <br />
         Código Aberto disponível sob GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1852,7 +1852,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Исходный код:</b><br />
-        Copyright &#169 2014-2022 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Исходный код доступен под лицензией GPLv3.
     ]]></string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1678,7 +1678,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>源代码:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         源代码在 GPLv3 许可下发布。
     ]]></string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1678,7 +1678,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>原始碼:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         原始碼在 GPLv3 許可下發佈。
     ]]></string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2164,7 +2164,7 @@
     ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />
-        Copyright &#169 2014-2023 Forrest Guice <br />
+        Copyright &#169 2014-2024 Forrest Guice <br />
         Source code available under GPLv3.
     ]]></string>
 

--- a/fastlane/metadata/android/en-US/changelogs/107.txt
+++ b/fastlane/metadata/android/en-US/changelogs/107.txt
@@ -1,1 +1,3 @@
+- adds experimental support for wearable devices (#727).
+- fixes bug "can't interact with app after install (flashes/strobes)" (#760).
 - updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/107.txt
+++ b/fastlane/metadata/android/en-US/changelogs/107.txt
@@ -1,0 +1,1 @@
+- updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* adds layouts and resources for very small screens (#727); experimental support for wearables.
* adds 'columns' setting to moon dialog; 2, 3 or 4 columns.
* fixes bug "can't interact with app after install (flashes/strobes)" (closes #760).
* fixes bug "custom date format is not saved"; adds calendar format pattern "EE, MMM d" (closes #759).
* fixes app crash when tapping on the date (closes #751).
* fixes bug where the solstice widget displays "cross-quarter days" when disabled by the app (#755).
* fixes bug where moon dialog content is clipped (#754).
* increments `CalculatorProviderContract` version 5 -> 6; fixes columns for "cross-quarter days".
* changes "header labels" default to "none" for translations with longer strings (de, fr, hu, nb, nl, pt_BR) (#754).
* miscellaneous updates to translations (closes #747).
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#752 by James Liu). #680 #681