### PR TITLE
release 0.15.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### ~
 
+### v0.15.12 (2024-03-01)
+* increases the range of supported dates from +-2.5 years to +-500 years (#770).
+* fixes bug where date selector allows selecting unsupported dates (#770), and other miscellaneous UI changes.
+* fixes bug where alarm screen back button overlaps the dismiss button (#777).
+* fixes bug in date widget where the scaled text is not centered (#763).
+* fixes ambiguity in minutes abbreviation; replaces "m" with "min" for all translations that default to metric (#773).
+* updates translation to Russian (ru) (#775 by Adelechka).
+
 ### v0.15.11 (2024-02-05)
 * adds "create/restore backup" option; saves all configuration data as json text (#757).
 * adds "export/import widget" option; save/load individual widget configurations.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Norwegian translation by <u>FTno</u>.<br/>
 Italian translation by <u>Matteo Caoduro</u> and <u>GiovaGa</u>.<br/>
 Traditional Chinese translation by <u><a href=https://github.com/pggdt>ft42</a></u>, and <u><a href=https://github.com/jamesliu96>James Liu</a></u>.<br />
 Brazilian Portuguese translation by <u><a href=https://github.com/netosilva15>NetoSilva</a></u>, <u>Nelson A. de Oliveira</u>, and <u>Enrico S. B. Fraletti</u>.<br />
-Russian translation by <u><a href=https://github.com/rchintsov>Ruslan Chintsov</a></u>.<br />
+Russian translation by <u><a href=https://github.com/rchintsov>Ruslan Chintsov</a></u>, and <u><a href=https://github.com/Adelechka>Adelechka</a></u>.<br />
 Dutch translation by <u><a href=https://github.com/joppla>Joppla</a></u>.<br />
 Czech translation by <u><a href=https://github.com/utaxiu>utaxiu</a></u>.<br />
 Simplified Chinese translation by <u><a href=https://github.com/jamesliu96>James Liu</a></u>, and <u><a href=https://github.com/sr093906>sr093906</a></u>.<br />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 108
-        versionName "0.15.11"
+        versionCode 109
+        versionName "0.15.12"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1774,7 +1774,7 @@
         <item><![CDATA[<a href=https://github.com/FTno>FTno</a>]]></item>
         <item><![CDATA[<a href=https://github.com/pggdt>ft42</a>|<a href=https://github.com/jamesliu96>James Liu</a>]]></item>
         <item><![CDATA[<a href=https://github.com/NetoSilva>Neto Silva</a>|<a href=https://github.com/naoliv>Nelson&#160;A.&#160;de&#160;Oliveira</a>|<a href=https://github.com/efraletti>Enrico S. B. Fraletti</a>]]></item>
-        <item><![CDATA[<a href=https://github.com/rchintsov>Ruslan&#160;Chintsov</a>]]></item>
+        <item><![CDATA[<a href=https://github.com/rchintsov>Ruslan&#160;Chintsov</a>|<a href=https://github.com/Adelechka>Adelechka</a>]]></item>
         <item><![CDATA[<a href=https://github.com/Joppla>Joppla</a>]]></item>
         <item><![CDATA[<a href=https://github.com/utaxiu>utaxiu</a>]]></item>
         <item><![CDATA[<a href=https://github.com/jamesliu96>James Liu</a>|<a href=https://github.com/sr093906>sr093906</a>]]></item>

--- a/fastlane/metadata/android/en-US/changelogs/109.txt
+++ b/fastlane/metadata/android/en-US/changelogs/109.txt
@@ -1,0 +1,2 @@
+- increases the range of supported dates.
+- updates translation to Russian.


### PR DESCRIPTION
* increases the range of supported dates from +-2.5 years to +-500 years (#770).
* fixes bug where date selector allows selecting unsupported dates (closes #770), and other miscellaneous UI changes.
* fixes bug where alarm screen back button overlaps the dismiss button (closes #777).
* fixes bug in date widget where the scaled text is not centered (closes #763).
* fixes ambiguity in minutes abbreviation; replaces "m" with "min" for all translations that default to metric (#773).
* updates translation to Russian (ru) (#775 by Adelechka).