### PR TITLE
release 0.15.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ### ~
 
-### v0.15.13 (2024-03-15)
+### v0.15.13 (2024-03-19)
 * adds app options to show daylight comparison (today/tomorrow) (#773).
+* increases the maximum before/after alarm offset (#779); fixes localization of display values.
 * fixes app crash when launching the app after using "restore backup" (#783).
+* replaces links to "online help" and improves help presentation; the app's website is now hosted on Codeberg (https://forrestguice.codeberg.page/Suntimes/) (#629).
+* now mirroring git repository to Codeberg (https://codeberg.org/forrestguice/Suntimes) (#629).
 
 ### v0.15.12 (2024-03-01)
 * increases the range of supported dates from +-2.5 years to +-500 years (#770).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### ~
 
 ### v0.15.13 (2024-03-15)
+* adds app options to show daylight comparison (today/tomorrow) (#773).
 * fixes app crash when launching the app after using "restore backup" (#783).
 
 ### v0.15.12 (2024-03-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### ~
 
+### v0.15.13 (2024-03-15)
+* fixes app crash when launching the app after using "restore backup" (#783).
+
 ### v0.15.12 (2024-03-01)
 * increases the range of supported dates from +-2.5 years to +-500 years (#770).
 * fixes bug where date selector allows selecting unsupported dates (#770), and other miscellaneous UI changes.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 109
-        versionName "0.15.12"
+        versionCode 110
+        versionName "0.15.13"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/110.txt
+++ b/fastlane/metadata/android/en-US/changelogs/110.txt
@@ -1,2 +1,3 @@
-- adds app options to show daylight comparison (today/tomorrow).
 - fixes app crash after using "restore backup" (#783).
+- increases the maximum before/after alarm offset.
+- adds app options to show daylight comparison (today/tomorrow).

--- a/fastlane/metadata/android/en-US/changelogs/110.txt
+++ b/fastlane/metadata/android/en-US/changelogs/110.txt
@@ -1,1 +1,2 @@
-- fixes app crash after using "restore backup".
+- adds app options to show daylight comparison (today/tomorrow).
+- fixes app crash after using "restore backup" (#783).

--- a/fastlane/metadata/android/en-US/changelogs/110.txt
+++ b/fastlane/metadata/android/en-US/changelogs/110.txt
@@ -1,0 +1,1 @@
+- fixes app crash after using "restore backup".


### PR DESCRIPTION
* adds app options to show daylight comparison (today/tomorrow) (closes #773).
* increases the maximum before/after alarm offset (closes #779); fixes localization of display values.
* fixes app crash when launching the app after using "restore backup" (closes #783).
* replaces links to "online help" and improves help presentation; the app's website is now hosted on Codeberg (https://forrestguice.codeberg.page/Suntimes/) (#629).
* now mirroring git repository to Codeberg (https://codeberg.org/forrestguice/Suntimes) (#629).