### PR TITLE
help urls

### DIFF
--- a/app/src/main/java/com/forrestguice/suntimeswidget/AboutActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/AboutActivity.java
@@ -216,7 +216,7 @@ public class AboutActivity extends AppCompatActivity
                 nameView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        AboutDialog.openLink(getActivity(), AboutDialog.WEBSITE_URL);
+                        AboutDialog.openLink(getActivity(), getString(R.string.help_app_url));
                     }
                 });
             }
@@ -230,18 +230,6 @@ public class AboutActivity extends AppCompatActivity
             if (versionView != null) {
                 versionView.setMovementMethod(LinkMovementMethod.getInstance());
                 versionView.setText(SuntimesUtils.fromHtml(htmlVersionString()));
-            }
-
-            TextView urlView = (TextView) dialogContent.findViewById(R.id.txt_about_url);
-            if (urlView != null) {
-                urlView.setMovementMethod(LinkMovementMethod.getInstance());
-                urlView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_url)));
-            }
-
-            TextView urlView1 = (TextView) dialogContent.findViewById(R.id.txt_about_url1);
-            if (urlView1 != null) {
-                urlView1.setMovementMethod(LinkMovementMethod.getInstance());
-                urlView1.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_source_url)));
             }
 
             TextView supportView = (TextView) dialogContent.findViewById(R.id.txt_about_support);
@@ -305,16 +293,15 @@ public class AboutActivity extends AppCompatActivity
                 legalView4.setText(SuntimesUtils.fromHtml(privacy));
             }
 
-            TextView legalView5 = (TextView) dialogContent.findViewById(R.id.txt_about_legal5);
-            if (legalView5 != null) {
-                legalView5.setMovementMethod(LinkMovementMethod.getInstance());
-                legalView5.setText(SuntimesUtils.fromHtml(context.getString(R.string.privacy_url)));
+            int[] linkViews = new int[] { R.id.txt_about_url, R.id.txt_about_url1, R.id.txt_about_legal5 };
+            for (int resID : linkViews)
+            {
+                TextView text = (TextView) dialogContent.findViewById(resID);
+                if (text != null) {
+                    text.setText(SuntimesUtils.fromHtml(AboutActivity.anchor(text.getText().toString())));
+                    text.setMovementMethod(LinkMovementMethod.getInstance());
+                }
             }
-        }
-
-        public static String anchor(String url, String text)
-        {
-            return "<a href=\"" + url + "\">" + text + "</a>";
         }
 
         protected static String smallText(String text)
@@ -324,14 +311,21 @@ public class AboutActivity extends AppCompatActivity
 
         public String htmlVersionString()
         {
-            String buildString = anchor(AboutDialog.COMMIT_URL + BuildConfig.GIT_HASH, BuildConfig.GIT_HASH);
-            String versionString = anchor(AboutDialog.CHANGELOG_URL, BuildConfig.VERSION_NAME) + " " + smallText("(" + buildString + ")");
+            String buildString = anchor(getString(R.string.help_commit_url) + BuildConfig.GIT_HASH, BuildConfig.GIT_HASH);
+            String versionString = anchor(getString(R.string.help_changelog_url), BuildConfig.VERSION_NAME) + " " + smallText("(" + buildString + ")");
             if (BuildConfig.DEBUG)
             {
                 versionString += " " + smallText("[" + BuildConfig.BUILD_TYPE + "]");
             }
             return getString(R.string.app_version, versionString);
         }
+    }
+
+    public static String anchor(String url) {
+        return anchor(url, url);
+    }
+    public static String anchor(String url, String text) {
+        return "<a href=\"" + url + "\">" + text + "</a>";
     }
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/AboutActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/AboutActivity.java
@@ -235,14 +235,14 @@ public class AboutActivity extends AppCompatActivity
             TextView supportView = (TextView) dialogContent.findViewById(R.id.txt_about_support);
             if (supportView != null) {
                 supportView.setMovementMethod(LinkMovementMethod.getInstance());
-                supportView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_support_url)));
+                supportView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_support_url, context.getString(R.string.help_support_url))));
             }
 
             final TextView donateView = (TextView) dialogContent.findViewById(R.id.txt_donate_url);
             if (donateView != null) {
                 donateView.setVisibility(View.GONE);
                 donateView.setMovementMethod(LinkMovementMethod.getInstance());
-                donateView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_donate_url, context.getString(R.string.app_name))));
+                donateView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_donate_url, context.getString(R.string.app_name), context.getString(R.string.help_donate_url))));
             }
 
             CheckBox checkDonate = (CheckBox) dialogContent.findViewById(R.id.check_donate);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/AboutDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/AboutDialog.java
@@ -186,7 +186,7 @@ public class AboutDialog extends BottomSheetDialogFragment
 
         TextView supportView = (TextView) dialogContent.findViewById(R.id.txt_about_support);
         supportView.setMovementMethod(LinkMovementMethod.getInstance());
-        supportView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_support_url)));
+        supportView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_support_url, context.getString(R.string.help_support_url))));
 
         TextView legalView1 = (TextView) dialogContent.findViewById(R.id.txt_about_legal1);
         legalView1.setMovementMethod(LinkMovementMethod.getInstance());

--- a/app/src/main/java/com/forrestguice/suntimeswidget/AboutDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/AboutDialog.java
@@ -50,12 +50,6 @@ import java.util.Comparator;
 
 public class AboutDialog extends BottomSheetDialogFragment
 {
-    public static final String WEBSITE_URL = "https://forrestguice.github.io/SuntimesWidget/";
-    public static final String ADDONS_URL = "https://forrestguice.github.io/SuntimesWidget/";
-    public static final String PRIVACY_URL = "https://github.com/forrestguice/SuntimesWidget/wiki/Privacy";
-    public static final String CHANGELOG_URL = "https://github.com/forrestguice/SuntimesWidget/blob/master/CHANGELOG.md";
-    public static final String COMMIT_URL = "https://github.com/forrestguice/SuntimesWidget/commit/";
-
     public static final String KEY_ICONID = "paramIconID";
     public static final String KEY_APPNAME = "paramAppName";
 
@@ -138,8 +132,10 @@ public class AboutDialog extends BottomSheetDialogFragment
         }
     }
 
-    public static String anchor(String url, String text)
-    {
+    public static String anchor(String url) {
+        return anchor(url, url);
+    }
+    public static String anchor(String url, String text) {
         return "<a href=\"" + url + "\">" + text + "</a>";
     }
 
@@ -150,8 +146,8 @@ public class AboutDialog extends BottomSheetDialogFragment
 
     public String htmlVersionString()
     {
-        String buildString = anchor(COMMIT_URL + BuildConfig.GIT_HASH, BuildConfig.GIT_HASH);
-        String versionString = anchor(CHANGELOG_URL, BuildConfig.VERSION_NAME) + " " + smallText("(" + buildString + ")");
+        String buildString = anchor(getString(R.string.help_commit_url) + BuildConfig.GIT_HASH, BuildConfig.GIT_HASH);
+        String versionString = anchor(getString(R.string.help_changelog_url), BuildConfig.VERSION_NAME) + " " + smallText("(" + buildString + ")");
         if (BuildConfig.DEBUG)
         {
             versionString += " " + smallText("[" + BuildConfig.BUILD_TYPE + "]");
@@ -177,7 +173,7 @@ public class AboutDialog extends BottomSheetDialogFragment
             @Override
             public void onClick(View v)
             {
-                openLink(getActivity(), WEBSITE_URL);
+                openLink(getActivity(), getString(R.string.help_app_url));
             }
         });
 
@@ -187,10 +183,6 @@ public class AboutDialog extends BottomSheetDialogFragment
         TextView versionView = (TextView) dialogContent.findViewById(R.id.txt_about_version);
         versionView.setMovementMethod(LinkMovementMethod.getInstance());
         versionView.setText(SuntimesUtils.fromHtml(htmlVersionString()));
-
-        TextView urlView = (TextView) dialogContent.findViewById(R.id.txt_about_url);
-        urlView.setMovementMethod(LinkMovementMethod.getInstance());
-        urlView.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_url)));
 
         TextView supportView = (TextView) dialogContent.findViewById(R.id.txt_about_support);
         supportView.setMovementMethod(LinkMovementMethod.getInstance());
@@ -222,9 +214,15 @@ public class AboutDialog extends BottomSheetDialogFragment
         String privacy = context.getString(R.string.privacy_policy, permissionsExplained);
         legalView4.setText(SuntimesUtils.fromHtml(privacy));
 
-        TextView legalView5 = (TextView) dialogContent.findViewById(R.id.txt_about_legal5);
-        legalView5.setMovementMethod(LinkMovementMethod.getInstance());
-        legalView5.setText(SuntimesUtils.fromHtml(context.getString(R.string.privacy_url)));
+        int[] linkViews = new int[] { R.id.txt_about_url, R.id.txt_about_legal5 };
+        for (int resID : linkViews)
+        {
+            TextView text = (TextView) dialogContent.findViewById(resID);
+            if (text != null) {
+                text.setText(SuntimesUtils.fromHtml(anchor(text.getText().toString())));
+                text.setMovementMethod(LinkMovementMethod.getInstance());
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesConfigActivity0.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesConfigActivity0.java
@@ -3000,7 +3000,7 @@ public class SuntimesConfigActivity0 extends AppCompatActivity
     {
         @Override
         public void onClick(View v) {
-            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.help_substitutions_url))));
+            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.help_url) + getString(R.string.help_substitutions_path))));
         }
     };
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/WelcomeActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/WelcomeActivity.java
@@ -453,7 +453,7 @@ public class WelcomeActivity extends AppCompatActivity
                 final TextView donateLink = (TextView) view.findViewById(R.id.link4);
                 if (donateLink != null) {
                     donateLink.setVisibility(View.GONE);
-                    donateLink.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_donate_url, context.getString(R.string.app_name))));
+                    donateLink.setText(SuntimesUtils.fromHtml(context.getString(R.string.app_donate_url, context.getString(R.string.app_name), context.getString(R.string.help_donate_url))));
                 }
 
                 CheckBox donateCheck = (CheckBox) view.findViewById(R.id.check_donate);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/WelcomeActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/WelcomeActivity.java
@@ -445,7 +445,7 @@ public class WelcomeActivity extends AppCompatActivity
                 for (int resID : textViews) {
                     TextView text = (TextView) view.findViewById(resID);
                     if (text != null) {
-                        text.setText(SuntimesUtils.fromHtml(text.getText().toString()));
+                        text.setText(SuntimesUtils.fromHtml(AboutActivity.anchor(text.getText().toString())));
                         text.setMovementMethod(LinkMovementMethod.getInstance());
                     }
                 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/actions/EditActionView.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/actions/EditActionView.java
@@ -893,7 +893,7 @@ public class EditActionView extends LinearLayout
         {
             Context context = getContext();
             if (context != null) {
-                getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.help_action_url))));
+                getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.help_url) + context.getString(R.string.help_action_path))));
             }
         }
     };

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmEditActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmEditActivity.java
@@ -964,7 +964,7 @@ public class AlarmEditActivity extends AppCompatActivity implements AlarmItemAda
         AlarmLabelDialog dialog = new AlarmLabelDialog();
         dialog.setDialogTitle(getString(R.string.alarmnote_dialog_title));
         dialog.setMultiLine(true);
-        dialog.setShowHelp(true, SuntimesUtils.fromHtml(getString(R.string.help_appearance_title)), getString(R.string.help_substitutions_url), HELPTAG_SUBSTITUTIONS);
+        dialog.setShowHelp(true, SuntimesUtils.fromHtml(getString(R.string.help_appearance_title)), getString(R.string.help_url) + getString(R.string.help_substitutions_path), HELPTAG_SUBSTITUTIONS);
         dialog.setAccentColor(colorAlarmEnabled);
         dialog.setLabel(item.note);
         dialog.setOnAcceptedListener(onNoteChanged);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/map/WorldMapDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/map/WorldMapDialog.java
@@ -1014,7 +1014,7 @@ public class WorldMapDialog extends BottomSheetDialogFragment
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-                            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.help_worldmap_background_url))));
+                            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.help_url) + context.getString(R.string.help_worldmap_background_path))));
                         }
                     })
                     .setNegativeButton(context.getString(R.string.dialog_cancel), null);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/HelpPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/HelpPreference.java
@@ -44,6 +44,7 @@ public class HelpPreference extends DialogPreference
 {
     private CharSequence helpText = "";
     private String helpLink = null;
+    private String helpPath = "";
     private TextView helpView;
 
     @TargetApi(21)
@@ -131,6 +132,7 @@ public class HelpPreference extends DialogPreference
             try {
                 this.helpText = SuntimesUtils.fromHtml(a.getString(R.styleable.HelpPreference_helpText));
                 helpLink = a.getString(R.styleable.HelpPreference_helpLink);
+                helpPath = a.getString(R.styleable.HelpPreference_helpPath);
                 buttonText = a.getString(R.styleable.HelpPreference_moreHelpButtonText);
             } finally {
                 a.recycle();
@@ -145,11 +147,14 @@ public class HelpPreference extends DialogPreference
     public void openHelpLink(Context context)
     {
         if (context != null && helpLink != null) {
-            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(helpLink)));
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(helpLink + helpPath)));
         }
     }
     public String getHelpLink() {
         return helpLink;
+    }
+    public String getHelpPath() {
+        return helpPath;
     }
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
@@ -487,7 +487,7 @@ public class AlarmPrefsFragment extends PreferenceFragment
                             @Override
                             public void onClick(DialogInterface dialog, int which)
                             {
-                                String url = context.getString(R.string.help_battery_optimization_url);
+                                String url = context.getString(R.string.help_url) + context.getString(R.string.help_battery_optimization_path);
                                 /*if (isAggressive) {
                                     url += "-" + Build.MANUFACTURER;
                                 }*/

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/CalendarPrefsFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/CalendarPrefsFragment.java
@@ -75,7 +75,7 @@ public class CalendarPrefsFragment extends PreferenceFragment
                 {
                     Activity activity = getActivity();
                     if (activity != null) {
-                        AboutDialog.openLink(activity, AboutDialog.ADDONS_URL);
+                        AboutDialog.openLink(activity, getString(R.string.help_addons_url));
                         activity.overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);
                     }
                     return false;

--- a/app/src/main/res/layout-land/layout_about_app.xml
+++ b/app/src/main/res/layout-land/layout_about_app.xml
@@ -77,7 +77,7 @@
                 android:layout_marginTop="0dp"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content" android:textSize="?attr/text_size_small"
-                android:text="@string/app_url"
+                android:text="@string/help_app_url"
                 android:autoLink="web" />
 
             <View

--- a/app/src/main/res/layout/layout_about_app.xml
+++ b/app/src/main/res/layout/layout_about_app.xml
@@ -76,7 +76,7 @@
             android:layout_marginTop="0dp"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content" android:textSize="?attr/text_size_small"
-            android:text="@string/app_url"
+            android:text="@string/help_app_url"
             android:autoLink="web" />
 
         <View android:visibility="gone"

--- a/app/src/main/res/layout/layout_about_contributions.xml
+++ b/app/src/main/res/layout/layout_about_contributions.xml
@@ -30,7 +30,7 @@
             android:layout_marginTop="0dp"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content" android:textSize="?attr/text_size_small"
-            android:text="@string/app_source_url"
+            android:text="@string/help_source_url"
             android:autoLink="web" />
 
         <View

--- a/app/src/main/res/layout/layout_about_privacy.xml
+++ b/app/src/main/res/layout/layout_about_privacy.xml
@@ -33,7 +33,7 @@
             android:layout_marginBottom="2dp"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content" android:textSize="?attr/text_size_small"
-            android:text="@string/privacy_url"
+            android:text="@string/help_privacy_url"
             android:autoLink="web" />
 
         <View

--- a/app/src/main/res/layout/layout_dialog_about.xml
+++ b/app/src/main/res/layout/layout_dialog_about.xml
@@ -96,7 +96,7 @@
             android:layout_marginTop="0dp"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content" android:textSize="?attr/text_size_small"
-            android:text="@string/app_url"
+            android:text="@string/help_app_url"
             android:autoLink="web" />
 
         <TextView
@@ -151,7 +151,7 @@
             android:layout_marginBottom="2dp"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content" android:textSize="?attr/text_size_small"
-            android:text="@string/privacy_url"
+            android:text="@string/help_privacy_url"
             android:autoLink="web" />
 
         <View

--- a/app/src/main/res/layout/layout_welcome_legal.xml
+++ b/app/src/main/res/layout/layout_welcome_legal.xml
@@ -61,7 +61,7 @@
                 android:gravity="start" android:layout_gravity="start"
                 android:layout_marginLeft="8dp" android:layout_marginRight="8dp"
                 android:layout_marginBottom="8dp"
-                android:text="@string/app_license_url" />
+                android:text="@string/help_license_url" />
 
             <TextView
                 android:id="@+id/text3" android:textSize="?attr/text_size_small"
@@ -73,7 +73,7 @@
                 android:id="@+id/link3" android:textSize="?attr/text_size_small"
                 android:layout_height="wrap_content" android:layout_width="wrap_content"
                 android:gravity="start" android:layout_margin="8dp" android:layout_gravity="start"
-                android:text="@string/privacy_url" />
+                android:text="@string/help_privacy_url" />
 
             <View
                 android:layout_width="match_parent"
@@ -85,7 +85,7 @@
                 android:gravity="start" android:layout_gravity="start"
                 android:layout_marginStart="8dp" android:layout_marginLeft="8dp"
                 android:layout_marginBottom="2dp" android:layout_marginTop="0dp"
-                android:text="@string/app_url" android:textSize="?attr/text_size_small" />
+                android:text="@string/help_app_url" android:textSize="?attr/text_size_small" />
 
             <LinearLayout android:orientation="horizontal"
                 android:layout_width="match_parent" android:layout_height="wrap_content"

--- a/app/src/main/res/values-ar-rSA/help_urls.xml
+++ b/app/src/main/res/values-ar-rSA/help_urls.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_url">@string/help_gh_url</string>
+    <string name="help_app_url">@string/help_app_gh_url</string>
+    <string name="help_addons_url">@string/help_addons_gh_url</string>
+    <string name="help_license_url">@string/help_license_gh_url</string>
+    <string name="help_privacy_url">@string/help_privacy_gh_url</string>
+    <string name="help_donate_url">@string/help_donate_gh_url</string>
+</resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2096,26 +2096,18 @@
     <string name="app_shortdesc">يعرض أوقات الشروق والغروب للشمس والقمر.</string>
     <string name="app_support_url"><![CDATA[
         <b>الدعم:</b> قم بزيارة
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">متعقب المشكلات</a> لتقديم طلب.
+        <a href="%1$s">متعقب المشكلات</a> لتقديم طلب.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s متاح مجانًا، ولكن إذا أثبتت قيمته، يُرجى
-        <a href="https://forrestguice.codeberg.page/Suntimes/donate">الدفع بالمبلغ الذي تريده</a>.
+        <a href="%2$s">الدفع بالمبلغ الذي تريده</a>.
     ]]></string>
-    <string name="app_source_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
-    ]]></xliff:g></string>
     <string name="app_license_about">أوقات الشمس هو برنامج مجاني ومفتوح المصدر.</string> <!-- displayed by welcome dialog -->
-    <string name="app_license_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes/license">https://forrestguice.codeberg.page/Suntimes/license</a>
-    ]]></xliff:g></string>
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes">https://forrestguice.codeberg.page/Suntimes</a>
-    ]]></xliff:g></string>
+
     <string name="app_legal1"><![CDATA[
-        <b>الشفرة المصدرية:</b><br />
-        حقوق النشر &#169 2014-2024 Forest Guice <br />
-        الشفرة المصدرية متاحة بموجب GPLv3.
+        <b>الشفرة المصدرية:</b><br/>
+        حقوق النشر 2014-2024 Forrest Guice &#169
+        <br/>الشفرة المصدرية متاحة بموجب GPLv3.
     ]]></string>
     <string name="app_legal2"><![CDATA[<b>الترجمات إلى:</b><br/>]]><xliff:g id="locale_credits">%1$s</xliff:g></string>
     <string name="translationCreditsFormat"><![CDATA[&#8226;&nbsp;<b><xliff:g id="languageName">%1$s</xliff:g></b> من قبل <xliff:g id="authorList">%2$s</xliff:g>.]]></string>
@@ -2367,9 +2359,6 @@
 <string name="privacy_permissiondialog_prompt"><![CDATA[هل ترغب في طلب الأذونات الآن؟]]></string>
 <string name="privacy_permissiondialog_ignore">تجاهل</string>
 <string name="privacy_permissiondialog_title">الأذونات</string>
-<string name="privacy_url"><xliff:g id="url"><![CDATA[
-    <a href="https://forrestguice.codeberg.page/Suntimes/privacy">https://forrestguice.codeberg.page/Suntimes/privacy</a>
-]]></xliff:g></string>
 <string name="privacyTab">الخصوصية</string>
 
     <string name="security_dialog_title">تنبيه أمان</string>

--- a/app/src/main/res/values-be/help_urls.xml
+++ b/app/src/main/res/values-be/help_urls.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_url">@string/help_gh_url</string>
+    <string name="help_app_url">@string/help_app_gh_url</string>
+    <string name="help_addons_url">@string/help_addons_gh_url</string>
+    <string name="help_license_url">@string/help_license_gh_url</string>
+    <string name="help_privacy_url">@string/help_privacy_gh_url</string>
+    <string name="help_donate_url">@string/help_donate_gh_url</string>
+</resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1707,11 +1707,11 @@
     <string name="app_shortdesc">Mostra les hores de l\'alba, capvespre, llum crepuscular i lunar.</string>
     <string name="app_support_url"><![CDATA[
         <b>Suport:</b> visita el
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">seguiment d\'incidències</a> per enviar una petició.
+        <a href="%1$s">seguiment d\'incidències</a> per enviar una petició.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
     <b>Codi font:</b><br />

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1817,11 +1817,11 @@
     <string name="app_shortdesc">Zobrazuje časy slunečního a měsíčního svitu.</string>
     <string name="app_support_url"><![CDATA[
         <b>Podpora:</b> navštivte
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> pro podání žádosti.
+        <a href="%1$s">issue tracker</a> pro podání žádosti.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
 
     <string name="app_legal1"><![CDATA[

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1823,12 +1823,7 @@
         %s is available gratis, but if it has proven its value, please
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
     ]]></string>    <!-- TODO -->
-    <string name="app_source_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
-    ]]></xliff:g></string>
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
+
     <string name="app_legal1"><![CDATA[
         <b>Zdrojový kód:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />
@@ -2077,9 +2072,6 @@
     <string name="privacy_permissiondialog_prompt"><![CDATA[Vyžádat oprávnění nyní?]]></string>
     <string name="privacy_permissiondialog_ignore">Ignorovat</string>
     <string name="privacy_permissiondialog_title">Oprávnění</string>
-    <string name="privacy_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/wiki/Privacy">github.com/forrestguice/SuntimesWidget/wiki/Privacy</a>
-    ]]></xliff:g></string>
     <string name="privacyTab">Sourkomí</string>
 
     <string name="security_dialog_title">Bezpečnostní upozornění</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1695,11 +1695,11 @@
   <string name="app_shortdesc">Eine App, die Auf- und Untergangszeiten von Sonne und Mond anzeigt.</string>
   <string name="app_support_url"><![CDATA[
       <b>Unterst&uuml;tzung:</b> besuchen Sie
-      <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> um eine Anfrage zu stellen.
+      <a href="%1$s">issue tracker</a> um eine Anfrage zu stellen.
   ]]></string>
   <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
   <string name="app_legal1"><![CDATA[
       Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-en-rCA/help_urls.xml
+++ b/app/src/main/res/values-en-rCA/help_urls.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_url">@string/help_gh_url</string>
+    <string name="help_app_url">@string/help_app_gh_url</string>
+    <string name="help_addons_url">@string/help_addons_gh_url</string>
+    <string name="help_license_url">@string/help_license_gh_url</string>
+    <string name="help_privacy_url">@string/help_privacy_gh_url</string>
+    <string name="help_donate_url">@string/help_donate_gh_url</string>
+</resources>

--- a/app/src/main/res/values-en-rUS/help_urls.xml
+++ b/app/src/main/res/values-en-rUS/help_urls.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_url">@string/help_gh_url</string>
+    <string name="help_app_url">@string/help_app_gh_url</string>
+    <string name="help_addons_url">@string/help_addons_gh_url</string>
+    <string name="help_license_url">@string/help_license_gh_url</string>
+    <string name="help_privacy_url">@string/help_privacy_gh_url</string>
+    <string name="help_donate_url">@string/help_donate_gh_url</string>
+</resources>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -1685,11 +1685,11 @@
     <string name="app_shortdesc">Montras tempojn de lumadoj de Suno kaj Luno.</string>
     <string name="app_support_url"><![CDATA[
         <b>Subteno:</b> vizitu la
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">erar-spurilon</a> por raporti problemon.
+        <a href="%1$s">erar-spurilon</a> por raporti problemon.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         La aplikaĵo %s estas disponebla senpage, sed se ĝi utilas al vi, bonvolu
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">konsideri donaci ajnan monkvanton</a>.
+        <a href="%2$s">konsideri donaci ajnan monkvanton</a>.
     ]]></string>
     <string name="app_license_about">La aplikaĵo Suntempoj estas libera kaj malfermkoda programaro.</string>   <!-- displayed by welcome dialog -->-->
     <string name="app_legal1"><![CDATA[

--- a/app/src/main/res/values-es-rMX/help_urls.xml
+++ b/app/src/main/res/values-es-rMX/help_urls.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_url">@string/help_gh_url</string>
+    <string name="help_app_url">@string/help_app_gh_url</string>
+    <string name="help_addons_url">@string/help_addons_gh_url</string>
+    <string name="help_license_url">@string/help_license_gh_url</string>
+    <string name="help_privacy_url">@string/help_privacy_gh_url</string>
+    <string name="help_donate_url">@string/help_donate_gh_url</string>
+</resources>

--- a/app/src/main/res/values-es-rUS/help_urls.xml
+++ b/app/src/main/res/values-es-rUS/help_urls.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_url">@string/help_gh_url</string>
+    <string name="help_app_url">@string/help_app_gh_url</string>
+    <string name="help_addons_url">@string/help_addons_gh_url</string>
+    <string name="help_license_url">@string/help_license_gh_url</string>
+    <string name="help_privacy_url">@string/help_privacy_gh_url</string>
+    <string name="help_donate_url">@string/help_donate_gh_url</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1693,11 +1693,11 @@
     <string name="app_shortdesc">Muestra las horas del amanecer, noche, luz crepuscular y lunar.</string>
     <string name="app_support_url"><![CDATA[
     <b>Soporte:</b> visita el
-    <a href="https://github.com/forrestguice/SuntimesWidget/issues">seguimiento de incidencias</a> para enviar una petición.
+    <a href="%1$s">seguimiento de incidencias</a> para enviar una petición.
 ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
     <b>Código fuente:</b> <br />

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -1724,9 +1724,6 @@
         %s is available gratis, but if it has proven its value, please
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
     ]]></string>    <!-- TODO -->
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Iturburu kodea:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -1718,11 +1718,11 @@
     <string name="app_shortdesc">Eguzki eta ilargiaren argiaren denborak erakusten ditu.</string>
     <string name="app_support_url"><![CDATA[
         <b>Laguntza:</b> joan zaitez
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">arazoen jarraitzailera</a> eskaera bat bidaltzeko.
+        <a href="%1$s">arazoen jarraitzailera</a> eskaera bat bidaltzeko.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
         <b>Iturburu kodea:</b><br />

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1682,11 +1682,11 @@
     <string name="app_shortdesc">Affiche les heures de lever et coucher de soleil et de la lune.</string>
     <string name="app_support_url"><![CDATA[
         <b>Support :</b> visitez le
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">gestionnaire de ticket</a> pour soumettre une requête.
+        <a href="%1$s">gestionnaire de ticket</a> pour soumettre une requête.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
         <b>Code source :</b><br />

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1686,11 +1686,11 @@
     <string name="app_shortdesc">Megjeleníti a napfény- és holdfényidőket.</string> 
     <string name="app_support_url"><![CDATA[
         <b>Támogatás:</b> keresse fel a
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">problémakövetőt</a> kérések benyújtásához.
+        <a href="%1$s">problémakövetőt</a> kérések benyújtásához.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
         <b>Forráskód:</b><br />

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1730,9 +1730,6 @@
         %s is available gratis, but if it has proven its value, please
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
     ]]></string>    <!-- TODO -->
-    <string name="app_url"><xliff:g id="url" ><![CDATA[
-             <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Codice sorgente:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1724,11 +1724,11 @@
     <string name="app_shortdesc">Visualizza orari di luce solare e luce lunare.</string>
     <string name="app_support_url"><![CDATA[
         <b>Support:</b> visita
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> per inviare una richiesta.
+        <a href="%1$s">issue tracker</a> per inviare una richiesta.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
         <b>Codice sorgente:</b><br />

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1706,11 +1706,11 @@
     <string name="app_shortdesc">Viser tider for sollys og månelys.</string>
     <string name="app_support_url"><![CDATA[
         <b>Support:</b> visit the
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> to submit a request.
+        <a href="%1$s">issue tracker</a> to submit a request.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_license_about">Suntimes er gratis og åpen kildekodeprogram.</string>   <!-- displayed by welcome dialog -->
     <string name="app_legal1"><![CDATA[

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1713,9 +1713,6 @@
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_license_about">Suntimes er gratis og åpen kildekodeprogram.</string>   <!-- displayed by welcome dialog -->
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Kildekode:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1803,12 +1803,6 @@
         %s is available gratis, but if it has proven its value, please
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
     ]]></string>    <!-- TODO -->
-    <!--<string name="app_source_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
-    ]]></xliff:g></string>-->
-    <!--<string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>-->
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1797,11 +1797,11 @@
     <string name="app_shortdesc">Displays sunlight and moonlight times.</string>
     <string name="app_support_url"><![CDATA[
         <b>Ondersteuning:</b> bezoek de
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> om een verzoek in te dienen.
+        <a href="%1$s">issue tracker</a> om een verzoek in te dienen.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1712,10 +1712,10 @@
     <string name="app_name_moonwidget0">Czasy Słońca: Księżyc</string>
     <string name="app_version"><![CDATA[<b>Wersja:</b>]]> <xliff:g id="versionString">%s</xliff:g></string>
     <string name="app_shortdesc">Wyświetla czasy świecenia Słońca i Księżyca.</string>
-    <string name="app_support_url"><![CDATA[<b>Wsparcie:</b> odwiedź <a href="https://github.com/forrestguice/SuntimesWidget/issues">stronę trackera błędów</a> aby zgłosić błąd/sugestię.]]></string>
+    <string name="app_support_url"><![CDATA[<b>Wsparcie:</b> odwiedź <a href="%1$s">stronę trackera błędów</a> aby zgłosić błąd/sugestię.]]></string>
     <string name="app_donate_url"><![CDATA[
         Aplikacja %s jest udostępniana bezpłatnie, ale jeżeli jest ona dla Ciebie użyteczna, prosimy
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">rozważyć wpłatę dowolnej kwoty</a>.
+        <a href="%2$s">rozważyć wpłatę dowolnej kwoty</a>.
     ]]></string>
     <string name="app_license_about">Aplikacja Czasy Słońca jest wolnym i otwartoźródłowym oprogramowaniem.</string>   <!-- displayed by welcome dialog -->-->
     <string name="app_legal1"><![CDATA[Prawo autorskie &#169 2014–2024 Forrest Guice <br />Kod źródłowy dostępny na licencji GPLv3.]]></string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1759,11 +1759,11 @@
     <string name="app_shortdesc">Exibe horários de luz solar e lunar.</string>
     <string name="app_support_url"><![CDATA[
         <b>Suporte:</b> visite
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">o gerenciador de ocorrências</a> para enviar uma solicitação.
+        <a href="%1$s">o gerenciador de ocorrências</a> para enviar uma solicitação.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>    <!-- TODO -->
     <string name="app_legal1"><![CDATA[
         <b>Código Aberto:</b><br />

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1765,9 +1765,6 @@
         %s is available gratis, but if it has proven its value, please
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">pay as you like</a>.
     ]]></string>    <!-- TODO -->
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>Código Aberto:</b><br />
         Direitos Reservados a &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1894,11 +1894,11 @@
     <string name="app_shortdesc">Показывает время солнечного и лунного освещения.</string>
     <string name="app_support_url"><![CDATA[
         <b>Поддержка:</b> посетите
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">трекер отслеживания проблем</a> на GitHub для создания запроса.
+        <a href="%1$s">трекер отслеживания проблем</a> на GitHub для создания запроса.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s предоставляется бесплатно, но если приложение оказалось полезным,
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">то можете пожертвовать деньги на ваше усмотрение</a>.
+        <a href="%2$s">то можете пожертвовать деньги на ваше усмотрение</a>.
     ]]></string>
 
     <string name="app_legal1"><![CDATA[

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1900,12 +1900,7 @@
         %s предоставляется бесплатно, но если приложение оказалось полезным,
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">то можете пожертвовать деньги на ваше усмотрение</a>.
     ]]></string>
-    <string name="app_source_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
-    ]]></xliff:g></string>
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
+
     <string name="app_legal1"><![CDATA[
         <b>Исходный код:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1723,9 +1723,6 @@
         %s 免费使用，如果您认为它有价值，请
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">随意付费</a>。
     ]]></string>
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>源代码:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1717,11 +1717,11 @@
     <string name="app_shortdesc">展示太阳和月亮的时间。</string>
     <string name="app_support_url"><![CDATA[
         <b>支持:</b> 访问
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">问题追踪器</a> 提交一个请求。
+        <a href="%1$s">问题追踪器</a> 提交一个请求。
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s 免费使用，如果您认为它有价值，请
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">随意付费</a>。
+        <a href="%2$s">随意付费</a>。
     ]]></string>
     <string name="app_legal1"><![CDATA[
         <b>源代码:</b><br />

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1717,11 +1717,11 @@
     <string name="app_shortdesc">展示太陽和月亮的時間。</string>
     <string name="app_support_url"><![CDATA[
         <b>支援:</b> 訪問
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">問題追踪器</a> 提交一個請求。
+        <a href="%1$s">問題追踪器</a> 提交一個請求。
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s 免費使用，如果您認為它有價值，請
-        <a href="https://forrestguice.github.io/SuntimesWidget/donate">隨意付費</a>。
+        <a href="%2$s">隨意付費</a>。
     ]]></string>
     <string name="app_legal1"><![CDATA[
         <b>原始碼:</b><br />

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1723,9 +1723,6 @@
         %s 免費使用，如果您認為它有價值，請
         <a href="https://forrestguice.github.io/SuntimesWidget/donate">隨意付費</a>。
     ]]></string>
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.github.io/SuntimesWidget/">forrestguice.github.io/SuntimesWidget</a>
-    ]]></xliff:g></string>
     <string name="app_legal1"><![CDATA[
         <b>原始碼:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -243,6 +243,7 @@
     <declare-styleable name="HelpPreference">
         <attr name="helpText" format="string" />
         <attr name="helpLink" format="string" />
+        <attr name="helpPath" format="string" />
         <attr name="moreHelpButtonText" format="string" />
     </declare-styleable>
 

--- a/app/src/main/res/values/help_urls.xml
+++ b/app/src/main/res/values/help_urls.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="http://schemas.android.com/tools">
+    
+    <string name="help_app_url">https://forrestguice.codeberg.page/Suntimes</string>
+    <string name="help_license_url">https://forrestguice.codeberg.page/Suntimes/license</string>
+    <string name="help_privacy_url">https://forrestguice.codeberg.page/Suntimes/privacy</string>
+    <string name="help_donate_url">https://forrestguice.codeberg.page/Suntimes/donate</string>
+    <string name="help_support_url">https://github.com/forrestguice/SuntimesWidget/issues</string>
+
+    <string name="help_action_url">https://forrestguice.codeberg.page/Suntimes/help/actions</string>
+    <string name="help_battery_optimization_url">https://forrestguice.codeberg.page/Suntimes/help/alarms/batteryopt</string>
+    <string name="help_datasources_url">https://forrestguice.codeberg.page/Suntimes/help/datasources</string>
+    <string name="help_substitutions_url">https://forrestguice.codeberg.page/Suntimes/help/datasubstitutions</string>
+    <string name="help_worldmap_background_url">https://forrestguice.codeberg.page/Suntimes/help/worldmap</string>
+
+    <string name="app_url"><xliff:g id="url"><![CDATA[
+        <a href="https://forrestguice.codeberg.page/Suntimes">https://forrestguice.codeberg.page/Suntimes</a>
+    ]]></xliff:g></string>
+
+    <string name="privacy_url"><xliff:g id="url"><![CDATA[
+        <a href="https://forrestguice.codeberg.page/Suntimes/privacy">https://forrestguice.codeberg.page/Suntimes/privacy</a>
+    ]]></xliff:g></string>
+
+    <string name="app_license_url"><xliff:g id="url"><![CDATA[
+        <a href="https://forrestguice.codeberg.page/Suntimes/license">https://forrestguice.codeberg.page/Suntimes/license</a>
+    ]]></xliff:g></string>
+
+    <string name="app_source_url"><xliff:g id="url"><![CDATA[
+        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
+    ]]></xliff:g></string>
+
+</resources>

--- a/app/src/main/res/values/help_urls.xml
+++ b/app/src/main/res/values/help_urls.xml
@@ -1,32 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:xliff="http://schemas.android.com/tools">
-    
+<resources>
+
+    <!-- app urls -->
     <string name="help_app_url">https://forrestguice.codeberg.page/Suntimes</string>
+    <string name="help_addons_url">https://forrestguice.codeberg.page/Suntimes</string>
     <string name="help_license_url">https://forrestguice.codeberg.page/Suntimes/license</string>
     <string name="help_privacy_url">https://forrestguice.codeberg.page/Suntimes/privacy</string>
     <string name="help_donate_url">https://forrestguice.codeberg.page/Suntimes/donate</string>
     <string name="help_support_url">https://github.com/forrestguice/SuntimesWidget/issues</string>
 
+    <string name="help_source_url">https://github.com/forrestguice/SuntimesWidget/</string>
+    <string name="help_changelog_url">https://github.com/forrestguice/SuntimesWidget/blob/master/CHANGELOG.md</string>
+    <string name="help_commit_url">https://github.com/forrestguice/SuntimesWidget/commit/</string>
+
+    <!-- help topics -->
     <string name="help_action_url">https://forrestguice.codeberg.page/Suntimes/help/actions</string>
     <string name="help_battery_optimization_url">https://forrestguice.codeberg.page/Suntimes/help/alarms/batteryopt</string>
     <string name="help_datasources_url">https://forrestguice.codeberg.page/Suntimes/help/datasources</string>
     <string name="help_substitutions_url">https://forrestguice.codeberg.page/Suntimes/help/datasubstitutions</string>
     <string name="help_worldmap_background_url">https://forrestguice.codeberg.page/Suntimes/help/worldmap</string>
-
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes">https://forrestguice.codeberg.page/Suntimes</a>
-    ]]></xliff:g></string>
-
-    <string name="privacy_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes/privacy">https://forrestguice.codeberg.page/Suntimes/privacy</a>
-    ]]></xliff:g></string>
-
-    <string name="app_license_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes/license">https://forrestguice.codeberg.page/Suntimes/license</a>
-    ]]></xliff:g></string>
-
-    <string name="app_source_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
-    ]]></xliff:g></string>
 
 </resources>

--- a/app/src/main/res/values/help_urls.xml
+++ b/app/src/main/res/values/help_urls.xml
@@ -8,16 +8,16 @@
     <string name="help_privacy_url">https://forrestguice.codeberg.page/Suntimes/privacy</string>
     <string name="help_donate_url">https://forrestguice.codeberg.page/Suntimes/donate</string>
     <string name="help_support_url">https://github.com/forrestguice/SuntimesWidget/issues</string>
+    <!-- Help Paths (these should be prefixed by `help_url`) -->
+    <string name="help_action_path" translatable="false">actions</string>
+    <string name="help_battery_optimization_path" translatable="false">alarms/batteryopt</string>
+    <string name="help_datasources_path" translatable="false">datasources</string>
+    <string name="help_substitutions_path" translatable="false">datasubstitutions</string>
+    <string name="help_worldmap_background_path" translatable="false">worldmap</string>
 
     <string name="help_source_url">https://github.com/forrestguice/SuntimesWidget/</string>
     <string name="help_changelog_url">https://github.com/forrestguice/SuntimesWidget/blob/master/CHANGELOG.md</string>
     <string name="help_commit_url">https://github.com/forrestguice/SuntimesWidget/commit/</string>
 
-    <!-- help topics -->
-    <string name="help_action_url">https://forrestguice.codeberg.page/Suntimes/help/actions</string>
-    <string name="help_battery_optimization_url">https://forrestguice.codeberg.page/Suntimes/help/alarms/batteryopt</string>
-    <string name="help_datasources_url">https://forrestguice.codeberg.page/Suntimes/help/datasources</string>
-    <string name="help_substitutions_url">https://forrestguice.codeberg.page/Suntimes/help/datasubstitutions</string>
-    <string name="help_worldmap_background_url">https://forrestguice.codeberg.page/Suntimes/help/worldmap</string>
 
 </resources>

--- a/app/src/main/res/values/help_urls.xml
+++ b/app/src/main/res/values/help_urls.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="help_url">@string/help_cb_url</string>       <!-- must end with / -->
 
-    <!-- app urls -->
-    <string name="help_app_url">https://forrestguice.codeberg.page/Suntimes</string>
-    <string name="help_addons_url">https://forrestguice.codeberg.page/Suntimes</string>
-    <string name="help_license_url">https://forrestguice.codeberg.page/Suntimes/license</string>
-    <string name="help_privacy_url">https://forrestguice.codeberg.page/Suntimes/privacy</string>
-    <string name="help_donate_url">https://forrestguice.codeberg.page/Suntimes/donate</string>
-    <string name="help_support_url">https://github.com/forrestguice/SuntimesWidget/issues</string>
     <!-- Help Paths (these should be prefixed by `help_url`) -->
     <string name="help_action_path" translatable="false">actions</string>
     <string name="help_battery_optimization_path" translatable="false">alarms/batteryopt</string>
@@ -15,9 +9,37 @@
     <string name="help_substitutions_path" translatable="false">datasubstitutions</string>
     <string name="help_worldmap_background_path" translatable="false">worldmap</string>
 
-    <string name="help_source_url">https://github.com/forrestguice/SuntimesWidget/</string>
-    <string name="help_changelog_url">https://github.com/forrestguice/SuntimesWidget/blob/master/CHANGELOG.md</string>
-    <string name="help_commit_url">https://github.com/forrestguice/SuntimesWidget/commit/</string>
+    <!-- App Links -->
+    <string name="help_app_url">@string/help_app_cb_url</string>
+    <string name="help_addons_url">@string/help_addons_cb_url</string>
+    <string name="help_license_url">@string/help_license_cb_url</string>
+    <string name="help_privacy_url">@string/help_privacy_cb_url</string>
+    <string name="help_donate_url">@string/help_donate_cb_url</string>
 
+    <string name="help_support_url">@string/help_support_gh_url</string>
+    <string name="help_source_url">@string/help_support_gh_url</string>
+    <string name="help_changelog_url">@string/help_changelog_gh_url</string>
+    <string name="help_commit_url">@string/help_commit_gh_url</string>
+
+    <!-- GitHub (mirror) -->
+    <string name="help_gh_url" translatable="false">https://forrestguice.github.io/Suntimes/help/</string>   <!-- must end with / -->
+    <string name="help_app_gh_url" translatable="false">https://forrestguice.github.io/Suntimes/</string>
+    <string name="help_addons_gh_url" translatable="false">https://forrestguice.github.io/Suntimes/</string>
+    <string name="help_license_gh_url" translatable="false">https://forrestguice.github.io/Suntimes/license</string>
+    <string name="help_privacy_gh_url" translatable="false">https://forrestguice.github.io/Suntimes/privacy</string>
+    <string name="help_donate_gh_url" translatable="false">https://forrestguice.github.io/Suntimes/donate</string>
+
+    <string name="help_support_gh_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/issues</string>
+    <string name="help_source_gh_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/</string>
+    <string name="help_changelog_gh_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/blob/master/CHANGELOG.md</string>
+    <string name="help_commit_gh_url" translatable="false">https://github.com/forrestguice/SuntimesWidget/commit/</string>
+
+    <!-- Codeberg (mirror) -->
+    <string name="help_cb_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/help/</string>   <!-- must end with / -->
+    <string name="help_app_cb_url" translatable="false">https://forrestguice.codeberg.page/Suntimes</string>
+    <string name="help_addons_cb_url" translatable="false">https://forrestguice.codeberg.page/Suntimes</string>
+    <string name="help_license_cb_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/license</string>
+    <string name="help_privacy_cb_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/privacy</string>
+    <string name="help_donate_cb_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/donate</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2214,11 +2214,11 @@
     <string name="app_shortdesc">Displays sunlight and moonlight times.</string>
     <string name="app_support_url"><![CDATA[
         <b>Support:</b> visit the
-        <a href="https://github.com/forrestguice/SuntimesWidget/issues">issue tracker</a> to submit a request.
+        <a href="%1$s">issue tracker</a> to submit a request.
     ]]></string>
     <string name="app_donate_url"><![CDATA[
         %s is available gratis, but if it has proven its value, please
-        <a href="https://forrestguice.codeberg.page/Suntimes/donate">pay as you like</a>.
+        <a href="%2$s">pay as you like</a>.
     ]]></string>
 
     <string name="app_license_about">Suntimes is free and open-source software.</string>   <!-- displayed by welcome dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1076,7 +1076,6 @@
     <string name="configLabel_alarms_autostart_summary">%1$s</string>                    <!-- "On", "Off" -->
     <string name="autostartWarning"><xliff:g id="warningTag">[w] Autostart is disabled!\nAlarms may fail to work after reboot.</xliff:g> </string>  <!-- snackbar message (xiomi devices only) -->
 
-    <string name="help_battery_optimization_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/help/alarms/batteryopt</string>
     <string-array name="aggressive_battery_known_offenders" translatable="false">    <!-- device manufacturer id; a warning will be displayed for these devices -->
         <item>Samsung</item>
         <item>OnePlus</item>
@@ -1880,7 +1879,6 @@
       \n\n<xliff:g id="proj4String" example="+proj4=eqd ..">%4$s</xliff:g>
       \n\nFor best results select an image matching these properties.
     </string>
-    <string name="help_worldmap_background_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/help/worldmap</string>
 
     <!-- Dialog: Light Map -->
     <string name="lightmap_dialog_title">@string/configAction_sunDialog</string>
@@ -2222,16 +2220,9 @@
         %s is available gratis, but if it has proven its value, please
         <a href="https://forrestguice.codeberg.page/Suntimes/donate">pay as you like</a>.
     ]]></string>
-    <string name="app_source_url"><xliff:g id="url"><![CDATA[
-        <a href="https://github.com/forrestguice/SuntimesWidget/">github.com/forrestguice/SuntimesWidget/</a>
-    ]]></xliff:g></string>
+
     <string name="app_license_about">Suntimes is free and open-source software.</string>   <!-- displayed by welcome dialog -->
-    <string name="app_license_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes/license">https://forrestguice.codeberg.page/Suntimes/license</a>
-    ]]></xliff:g></string>
-    <string name="app_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes">https://forrestguice.codeberg.page/Suntimes</a>
-    ]]></xliff:g></string>
+
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />
         Copyright &#169 2014-2024 Forrest Guice <br />
@@ -2316,7 +2307,6 @@
                 * <b>%M</b> for mode (long) (e.g. Winter Solstice) <br/>
                 * <b>%o</b> for order (e.g. Closest Event, Upcoming Event) <br/>
     ]]></string>    <!-- TODO: added section "Date Widgets:", add "%em, %et, %eT, %eA" (#599) to online-help -->
-    <string name="help_substitutions_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/help/datasubstitutions</string>
 
     <string name="help_general2">  <!-- general app help; composites a couple help topics together. -->
         <xliff:g id="help_topic1">%1$s</xliff:g><![CDATA[<br />]]>
@@ -2461,7 +2451,7 @@
         <br/>
         <b>Extras:</b> An <em>&amp;</em> delimited string containing extra values. Supports <em>%s</em>ubstitutions.<br/><br/>Values may be <em>int</em>, <em>long</em>, <em>double</em>, <em>float</em>, <em>boolean</em> or String. <small>e.g. <em>key1=value1 & int=1 & long=1L & double=1D & float=1F & bool=true & etc=%dm</em></small>
     ]]></string>
-    <string name="help_action_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/help/actions</string>
+
     <string name="help_widgetlist"><![CDATA[
           To <b>add</b> or <b>remove</b> a widget you must navigate to the home screen.<br/><br/>
           To <b>reconfigure</b> an existing widget you can select from the following list.<br/>
@@ -2491,9 +2481,6 @@
     <string name="privacy_permissiondialog_prompt"><![CDATA[Request permissions now?]]></string>
     <string name="privacy_permissiondialog_ignore">Ignore</string>
     <string name="privacy_permissiondialog_title">Permissions</string>
-    <string name="privacy_url"><xliff:g id="url"><![CDATA[
-        <a href="https://forrestguice.codeberg.page/Suntimes/privacy">https://forrestguice.codeberg.page/Suntimes/privacy</a>
-    ]]></xliff:g></string>
     <string name="privacyTab">Privacy</string>
 
     <string name="security_dialog_title">Security Alert</string>
@@ -2525,7 +2512,6 @@
         For more information about available choices, or extending the app to support other libraries, see the online help.
     ]]>
     </string>
-    <string name="help_datasources_url" translatable="false">https://forrestguice.codeberg.page/Suntimes/help/datasources</string>
 
     <!-- pref defaults -->
     <string name="def_appwidget_0_general_calculator" translatable="false">time4a-time4j</string>

--- a/app/src/main/res/xml/preference_general.xml
+++ b/app/src/main/res/xml/preference_general.xml
@@ -68,7 +68,8 @@
             android:title="@string/configLabel_general_calculator_help"
             android:icon="?attr/icActionHelp"
             app:helpText="@string/help_datasources"
-            app:helpLink="@string/help_datasources_url"
+            app:helpLink="@string/help_url"
+            app:helpPath="@string/help_datasources_path"
             app:moreHelpButtonText="@string/configAction_onlineHelp"
             />
 


### PR DESCRIPTION
* moves url definitions into `help_urls` resources.
* localizes urls; some locales point to the GitHub mirror instead (#629).