### PR TITLE
release 0.15.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### ~
 
-### v0.15.15 (2024-05-10)
+### v0.15.15 (2024-05-14)
+* adds online user manual; https://forrestguice.github.io/Suntimes/help/ or https://forrestguice.codeberg.page/Suntimes/help/
 * fixes app crash when using custom themes (#792).
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#791 by James Liu).
 * updates translation to Polish and Esperanto (eo, pl) (#793 by Verdulo).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.15.15 (2024-05-10)
+* fixes app crash when using custom themes (#792).
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#791 by James Liu).
+* updates translation to Polish and Esperanto (eo, pl) (#793 by Verdulo).
+
 ### v0.15.14 (2024-04-15)
 * adds translation to Arabic (ar) (contributed by Alelg) (#786).
 * adds to list of world places, and allows adding world places by continent (#785).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 111
-        versionName "0.15.14"
+        versionCode 112
+        versionName "0.15.15"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/112.txt
+++ b/fastlane/metadata/android/en-US/changelogs/112.txt
@@ -1,0 +1,1 @@
+- fixes app crash when using custom themes (#792).

--- a/fastlane/metadata/android/en-US/changelogs/112.txt
+++ b/fastlane/metadata/android/en-US/changelogs/112.txt
@@ -1,1 +1,4 @@
+- adds online user manual (https://forrestguice.codeberg.page/Suntimes/help/).
 - fixes app crash when using custom themes (#792).
+- updates translation to Polish and Esperanto.
+- updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* adds online user manual; https://forrestguice.github.io/Suntimes/help/ or https://forrestguice.codeberg.page/Suntimes/help/
* fixes app crash when using custom themes (closes #792).
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#791 by James Liu).
* updates translation to Polish and Esperanto (eo, pl) (#793 by Verdulo).