### PR TITLE
release 0.15.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.15.16 (2024-06-17)
+* adds "online help" links to existing help dialogs (#797).
+* fixes bug where "moon phase alarm time is incorrect" (#803).
+* fixes bugs when using d-pad navigation within dialogs (Android TV).
+* updates translation to Norwegian (nb) (#796, #801 by FTno).
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#799, #800 by James Liu).
+
 ### v0.15.15 (2024-05-14)
 * adds online user manual; https://forrestguice.github.io/Suntimes/help/ or https://forrestguice.codeberg.page/Suntimes/help/
 * fixes app crash when using custom themes (#792).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 10
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 112
-        versionName "0.15.15"
+        versionCode 113
+        versionName "0.15.16"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/113.txt
+++ b/fastlane/metadata/android/en-US/changelogs/113.txt
@@ -1,0 +1,4 @@
+- fixes bug where "moon phase alarm time is incorrect" (#803).
+- fixes bugs when using d-pad navigation within dialogs (Android TV).
+- updates translation to Norwegian.
+- updates translations to Simplified Chinese, and Traditional Chinese.


### PR DESCRIPTION
* adds "online help" links to existing help dialogs (closes #797).
* fixes bug where "moon phase alarm time is incorrect" (closes #803).
* fixes bugs when using d-pad navigation within dialogs (Android TV).
* updates translation to Norwegian (nb) (#796, #801 by FTno). #674 
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#799, #800 by James Liu). #680 #681