### PR TITLE
release 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ### ~
 
 ### v0.16.1 (2024-08-19)
-* adds "material colors" (palette) to color dialog.
+* adds "material palette" to the color dialog.
 * adds text color preview, and other miscellaneous color picker improvements.
 * adds "cross-hair" option to sunlight graph; adds "share bitmap" action.
 * fixes sunlight graph so that it shows jump/skip in time zone dst (#735).
 * fixes inconsistent text/point sizes between graph views.
 * fixes bug where the lightmap widget is rendered incorrectly (#812).
+* fixes bug where "sunlight dialog axis labels don't follow user settings (always 12 hour time)". (#824)
 * enhances Alarm Settings warnings; show a warning when alarm notifications are disabled on the lock screen (#332).
 * enhances Alarm Settings warnings; show warnings when alarm channel is muted, or notifications are temporarily paused/suspended.
 * fixes broken "full-screen notifications" preference click listener; the UI now reports the current state of the required permission (#802).
@@ -18,6 +19,7 @@
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#813 by James Liu).
 * updates translation to Norwegian (nb) (#817 by FTno).
 * updates translation to Brazilian Portuguese (pt-br) (#819 by naoliv).
+* updates translation to Polish and Esperanto (eo, pl) (#824 by Verdulo).
 
 ### v0.16.0 (2024-07-31)
 * adds "sidebar navigation", and an option to change the "launcher activity" (#505).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ### ~
 
+### v0.16.1 (2024-08-19)
+* adds "material colors" (palette) to color dialog.
+* adds text color preview, and other miscellaneous color picker improvements.
+* adds "cross-hair" option to sunlight graph; adds "share bitmap" action.
+* fixes sunlight graph so that it shows jump/skip in time zone dst (#735).
+* fixes inconsistent text/point sizes between graph views.
+* fixes bug where the lightmap widget is rendered incorrectly (#812).
+* enhances Alarm Settings warnings; show a warning when alarm notifications are disabled on the lock screen (#332).
+* enhances Alarm Settings warnings; show warnings when alarm channel is muted, or notifications are temporarily paused/suspended.
+* fixes broken "full-screen notifications" preference click listener; the UI now reports the current state of the required permission (#802).
+* fixes bug "widget does not update automatically" (#806); periodically detects and recovers stale widgets.
+* fixes bug where the alarm dialog fails to switch to the correct tab when scheduling events.
+* fixes bug where dialog updates continue running after the dialog is closed.
+* fixes bugs in color dialog related to `FragmentPagerAdapter`; fixes crash in color dialog on rotation.
+* fixes bug where color sheet fails to retain state on rotation.
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#813 by James Liu).
+* updates translation to Norwegian (nb) (#817 by FTno).
+* updates translation to Brazilian Portuguese (pt-br) (#819 by naoliv).
+
 ### v0.16.0 (2024-07-31)
 * adds "sidebar navigation", and an option to change the "launcher activity" (#505).
 * adds support for custom events based on "shadow length" (#331).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 114
-        versionName "0.16.0"
+        versionCode 115
+        versionName "0.16.1"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/115.txt
+++ b/fastlane/metadata/android/en-US/changelogs/115.txt
@@ -1,0 +1,7 @@
+- fixes bug "widget does not update automatically" (#806).
+- fixes bug in the sunlight graph (show jump/skip due to dst).
+- adds "cross-hair" and "share" options to sunlight graph.
+- adds "material palette" (and other color dialog enhancements).
+- updates translation to Brazilian Portuguese.
+- updates translation to Norwegian.
+- updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/115.txt
+++ b/fastlane/metadata/android/en-US/changelogs/115.txt
@@ -1,7 +1,8 @@
 - fixes bug "widget does not update automatically" (#806).
-- fixes bug in the sunlight graph (show jump/skip due to dst).
+- fixes bugs in the sunlight graph.
 - adds "cross-hair" and "share" options to sunlight graph.
-- adds "material palette" (and other color dialog enhancements).
-- updates translation to Brazilian Portuguese.
-- updates translation to Norwegian.
+- adds "material palette" to the color dialog (and other enhancements).
 - updates translations to Simplified Chinese, and Traditional Chinese.
+- updates translation to Norwegian.
+- updates translation to Brazilian Portuguese.
+- updates translation to Polish and Esperanto.


### PR DESCRIPTION
### v0.16.1 (2024-08-19)
* adds "material colors" (palette) to color dialog.
* adds text color preview, and other miscellaneous color picker improvements.
* adds "cross-hair" option to sunlight graph; adds "share bitmap" action.
* fixes sunlight graph so that it shows jump/skip in time zone dst (closes #735).
* fixes inconsistent text/point sizes between graph views.
* fixes bug where the lightmap widget is rendered incorrectly (closes #812).
* fixes bug where "sunlight dialog axis labels don't follow user settings (always 12 hour time)". (#824)
* enhances Alarm Settings warnings; show a warning when alarm notifications are disabled on the lock screen (closes #332).
* enhances Alarm Settings warnings; show warnings when alarm channel is muted, or notifications are temporarily paused/suspended.
* fixes broken "full-screen notifications" preference click listener; the UI now reports the current state of the required permission (#802).
* fixes bug "widget does not update automatically" (closes #806); periodically detects and recovers stale widgets.
* fixes bug where the alarm dialog fails to switch to the correct tab when scheduling events.
* fixes bug where dialog updates continue running after the dialog is closed.
* fixes bugs in color dialog related to `FragmentPagerAdapter`; fixes crash in color dialog on rotation.
* fixes bug where color sheet fails to retain state on rotation.
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#813 by James Liu). #680 #681
* updates translation to Norwegian (nb) (#817 by FTno). #674
* updates translation to Brazilian Portuguese (pt-br) (#819 by naoliv). #682 
* updates translation to Polish and Esperanto (eo, pl) (#824 by Verdulo). #662 #663