### PR TITLE
preferences

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -249,6 +249,12 @@
                 <data android:scheme="color" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".colors.ColorValuesSheetActivity"
+            android:label="@string/configAction_colors"
+            android:icon="@drawable/ic_palette"
+            android:exported="false">
+        </activity>
 
         <!-- FileProvider (export to file; places, themes) -->
         <provider

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesSettingsActivity.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2014-2023 Forrest Guice
+    Copyright (C) 2014-2024 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -37,8 +37,10 @@ import android.support.annotation.StringRes;
 import android.util.Log;
 import android.util.TypedValue;
 
-
 import com.forrestguice.suntimeswidget.alarmclock.bedtime.BedtimeSettings;
+import com.forrestguice.suntimeswidget.colors.ColorValues;
+import com.forrestguice.suntimeswidget.colors.ColorValuesCollection;
+import com.forrestguice.suntimeswidget.colors.ColorValuesSheetActivity;
 import com.forrestguice.suntimeswidget.settings.SettingsActivityInterface;
 import com.forrestguice.suntimeswidget.settings.WidgetSettingsPreferenceHelper;
 import com.forrestguice.suntimeswidget.settings.fragments.AlarmPrefsFragment;
@@ -187,6 +189,10 @@ public class SuntimesSettingsActivity extends PreferenceActivity
             case SettingsActivityInterface.REQUEST_MANAGE_EVENTS:
                 onManageEvents(requestCode, resultCode, data);
                 break;
+
+            case SettingsActivityInterface.REQUEST_PICKCOLORS_BRIGHTALARM:
+                onPickColors(requestCode, resultCode, data);
+                break;
         }
     }
 
@@ -200,6 +206,7 @@ public class SuntimesSettingsActivity extends PreferenceActivity
             case SettingsActivityInterface.REQUEST_TAPACTION_DATE0: return AppSettings.PREF_KEY_UI_DATETAPACTION;
             case SettingsActivityInterface.REQUEST_TAPACTION_DATE1: return AppSettings.PREF_KEY_UI_DATETAPACTION1;
             case SettingsActivityInterface.REQUEST_TAPACTION_NOTE:  return AppSettings.PREF_KEY_UI_NOTETAPACTION;
+            case SettingsActivityInterface.REQUEST_PICKCOLORS_BRIGHTALARM: return AlarmSettings.PREF_KEY_ALARM_BRIGHTMODE_COLORS;
             default: return null;
         }
     }
@@ -245,6 +252,27 @@ public class SuntimesSettingsActivity extends PreferenceActivity
             } else if (adapterModified) {
                 rebuildActivity();
             }
+        }
+    }
+
+    private void onPickColors(int requestCode, int resultCode, Intent data)
+    {
+        if (resultCode == RESULT_OK)
+        {
+            String selection = data.getStringExtra(ColorValuesSheetActivity.EXTRA_SELECTED_COLORS_ID);
+            //Log.d("DEBUG", "onPickColors: " + selection);
+
+            int appWidgetID = data.getIntExtra(ColorValuesSheetActivity.EXTRA_APPWIDGET_ID, 0);
+            String colorTag = data.getStringExtra(ColorValuesSheetActivity.EXTRA_COLORTAG);
+            ColorValuesCollection<ColorValues> collection = data.getParcelableExtra(ColorValuesSheetActivity.EXTRA_COLLECTION);
+
+            if (collection != null) {
+                collection.setSelectedColorsID(context, selection, appWidgetID, colorTag);
+            }
+
+            SharedPreferences.Editor pref = PreferenceManager.getDefaultSharedPreferences(context).edit();
+            pref.putString(prefKeyForRequestCode(requestCode), selection);
+            pref.apply();
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesUtils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/SuntimesUtils.java
@@ -28,6 +28,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.LightingColorFilter;
 import android.graphics.Paint;
+import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.GradientDrawable;
@@ -58,6 +59,7 @@ import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.ImageSpan;
 import android.text.style.RelativeSizeSpan;
+import android.text.style.ReplacementSpan;
 import android.text.style.UnderlineSpan;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -1858,6 +1860,42 @@ public class SuntimesUtils
                 span.setSpan(createImageSpan(imageSpan), tagPos, tagEnd, alignment);
                 text = text.subSequence(0, tagPos) + tag.getBlank() + text.subSequence(tagEnd, text.length());
             }
+        }
+        return span;
+    }
+
+    public static SpannableString createRoundedBackgroundColorSpan(SpannableString span, String text, String toColorize,
+                                                                   final int textColor, final boolean boldText,
+                                                                   final int backgroundColor, final float cornerRadiusPx, final float paddingPx)
+    {
+        ReplacementSpan replacementSpan = new ReplacementSpan()
+        {
+            @Override
+            public int getSize(@NonNull Paint p, CharSequence t, int start, int end, @Nullable Paint.FontMetricsInt fontMetrics) {
+                return (int) Math.ceil(p.measureText(t, start, end) + (2 * paddingPx));
+            }
+
+            @Override
+            public void draw(@NonNull Canvas c, CharSequence t, int start, int end, float x, int top, int y, int bottom, @NonNull Paint p)
+            {
+                p.setColor(backgroundColor);
+                RectF rect = new RectF(x, top, x + p.measureText(t, start, end) + (2 * paddingPx), bottom);
+                c.drawRoundRect(rect, cornerRadiusPx, cornerRadiusPx, p);
+
+                p.setColor(textColor);
+                p.setTypeface(boldText ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
+                c.drawText(t, start, end, x + paddingPx, y, p);
+            }
+        };
+
+        if (span == null) {
+            span = new SpannableString(text);
+        }
+        int start = text.indexOf(toColorize);
+        if (start >= 0)
+        {
+            int end = start + toColorize.length() + 1;  // 1 beyond last character
+            span.setSpan(replacementSpan, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
         return span;
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -136,6 +136,7 @@ public class AlarmSettings
 
     public static final String PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR = "app_alarms_bright_color_start";
     public static final String PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR = "app_alarms_bright_color_end";
+    public static final String PREF_KEY_ALARM_BRIGHTMODE_COLORS = "app_alarms_bright_colors";
 
     public static final String PREF_KEY_ALARM_FADEIN = "app_alarms_fadeinMillis";
     public static final int PREF_DEF_ALARM_FADEIN = 1000 * 10;   // 10 s

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -134,8 +134,8 @@ public class AlarmSettings
     public static final String PREF_KEY_ALARM_BRIGHTMODE_FADEIN = "app_alarms_bright_fadeinMillis";
     public static final int PREF_DEF_ALARM_BRIGHTMODE_FADEIN = 1000 * 60;   // 60 s
 
-    public static final String PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR = "app_alarms_bright_color_start";
-    public static final String PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR = "app_alarms_bright_color_end";
+    //public static final String PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR = "app_alarms_bright_color_start";
+    //public static final String PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR = "app_alarms_bright_color_end";
     public static final String PREF_KEY_ALARM_BRIGHTMODE_COLORS = "app_alarms_bright_colors";
 
     public static final String PREF_KEY_ALARM_FADEIN = "app_alarms_fadeinMillis";
@@ -172,7 +172,7 @@ public class AlarmSettings
             PREF_KEY_ALARM_ALLRINGTONES, PREF_KEY_ALARM_SHOWLAUNCHER,
             PREF_KEY_ALARM_POWEROFFALARMS, PREF_KEY_ALARM_UPCOMING_ALARMID,
             PREF_KEY_ALARM_SYSTEM_TIMEZONE_ID, PREF_KEY_ALARM_SYSTEM_TIMEZONE_OFFSET,
-            PREF_KEY_ALARM_BRIGHTMODE, PREF_KEY_ALARM_BRIGHTMODE_FADEIN, PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR,
+            PREF_KEY_ALARM_BRIGHTMODE, PREF_KEY_ALARM_BRIGHTMODE_FADEIN, // PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR,
             PREF_KEY_ALARM_FADEIN, PREF_KEY_ALARM_DISMISS_CHALLENGE,
             PREF_KEY_ALARM_SORT, PREF_KEY_ALARM_SORT_ENABLED_FIRST, PREF_KEY_ALARM_SORT_SHOW_OFFSET,
             PREF_KEY_ALARM_BOOTCOMPLETED, PREF_KEY_ALARM_BOOTCOMPLETED_ATELAPSED, PREF_KEY_ALARM_BOOTCOMPLETED_DURATION, PREF_KEY_ALARM_BOOTCOMPLETED_RESULT,
@@ -187,7 +187,7 @@ public class AlarmSettings
             PREF_KEY_ALARM_SNOOZE, PREF_KEY_ALARM_SNOOZE_LIMIT,
             PREF_KEY_ALARM_UPCOMING, PREF_KEY_ALARM_AUTODISMISS,
             PREF_KEY_ALARM_FADEIN, PREF_KEY_ALARM_SORT,
-            PREF_KEY_ALARM_BRIGHTMODE_FADEIN, PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR,
+            PREF_KEY_ALARM_BRIGHTMODE_FADEIN, // PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR,
     };
     public static final String[] BOOL_KEYS = new String[]
     {
@@ -420,7 +420,7 @@ public class AlarmSettings
         } else return loadStringPrefAsLong(prefs, PREF_KEY_ALARM_BRIGHTMODE_FADEIN, PREF_DEF_ALARM_BRIGHTMODE_FADEIN);
     }
 
-    public static int[] loadPrefAlarmBrightColors(Context context)
+    /*public static int[] loadPrefAlarmBrightColors(Context context)
     {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if (Build.VERSION.SDK_INT >= 11) {
@@ -434,7 +434,7 @@ public class AlarmSettings
                     (int) loadStringPrefAsLong(prefs, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR, ContextCompat.getColor(context, R.color.def_app_alarms_bright_color_end))
             };
         }
-    }
+    }*/
 
     public static long loadPrefAlarmFadeIn(Context context)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmSettings.java
@@ -132,11 +132,8 @@ public class AlarmSettings
     public static final String PREF_KEY_ALARM_BRIGHTMODE_FADEIN = "app_alarms_bright_fadeinMillis";
     public static final int PREF_DEF_ALARM_BRIGHTMODE_FADEIN = 1000 * 60;   // 60 s
 
-    public static final String PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR = "app_alarms_bright_colorend";
-    public static final int PREF_DEF_ALARM_BRIGHTMODE_STARTCOLOR = Color.BLACK;
-
-    public static final String PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR = "app_alarms_bright_colorstart";
-    public static final int PREF_DEF_ALARM_BRIGHTMODE_ENDCOLOR = Color.WHITE;
+    public static final String PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR = "app_alarms_bright_color_start";
+    public static final String PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR = "app_alarms_bright_color_end";
 
     public static final String PREF_KEY_ALARM_FADEIN = "app_alarms_fadeinMillis";
     public static final int PREF_DEF_ALARM_FADEIN = 1000 * 10;   // 10 s
@@ -425,13 +422,13 @@ public class AlarmSettings
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if (Build.VERSION.SDK_INT >= 11) {
             return new int[] {
-                    prefs.getInt(PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, PREF_DEF_ALARM_BRIGHTMODE_STARTCOLOR),
-                    prefs.getInt(PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR, PREF_DEF_ALARM_BRIGHTMODE_ENDCOLOR)
+                    prefs.getInt(PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, ContextCompat.getColor(context, R.color.def_app_alarms_bright_color_start)),
+                    prefs.getInt(PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR, ContextCompat.getColor(context, R.color.def_app_alarms_bright_color_end))
             };
         } else {
             return new int[]{
-                    (int) loadStringPrefAsLong(prefs, PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, PREF_DEF_ALARM_BRIGHTMODE_STARTCOLOR),
-                    (int) loadStringPrefAsLong(prefs, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR, PREF_DEF_ALARM_BRIGHTMODE_ENDCOLOR)
+                    (int) loadStringPrefAsLong(prefs, PREF_KEY_ALARM_BRIGHTMODE_STARTCOLOR, ContextCompat.getColor(context, R.color.def_app_alarms_bright_color_start)),
+                    (int) loadStringPrefAsLong(prefs, PREF_KEY_ALARM_BRIGHTMODE_ENDCOLOR, ContextCompat.getColor(context, R.color.def_app_alarms_bright_color_end))
             };
         }
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmButton.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmButton.java
@@ -92,6 +92,7 @@ public class AlarmButton extends RelativeLayout
     protected View dragHint;
     protected View[] hintViews;
     protected View[] allDragHints;
+    protected TextView[] allDragHintText;
     protected View[] allDragTargets;
     protected View shade;
 
@@ -164,6 +165,13 @@ public class AlarmButton extends RelativeLayout
             hint.setVisibility(View.GONE);
         }
 
+        allDragHintText = new TextView[] {
+                (TextView) findViewById(R.id.text_drag_hint_start),
+                (TextView) findViewById(R.id.text_drag_hint_top),
+                (TextView) findViewById(R.id.text_drag_hint_end),
+                (TextView) findViewById(R.id.text_drag_hint_bottom)
+        };
+
         dragHint = (activatedDirection == ACTIVATED_END ? allDragHints[2] : allDragHints[0]);
         dragHint.setVisibility(View.VISIBLE);
         dragHint.setAlpha(0);
@@ -177,9 +185,7 @@ public class AlarmButton extends RelativeLayout
         frameTop = findViewById(R.id.frame_top);
         frameBottom = findViewById(R.id.frame_bottom);
 
-        if (activatedDirection == ACTIVATED_END) {
-            frameEnd.setBackgroundColor(color_accent);
-        } else frameStart.setBackgroundColor(color_accent);
+        setAccentColor(color_accent);
 
         hintViews = new View[] { dragHint, (activatedDirection == ACTIVATED_END) ? frameEnd : frameStart };
         frameViews = new View[] { frameStart, frameTop, frameEnd, frameBottom };
@@ -481,6 +487,36 @@ public class AlarmButton extends RelativeLayout
             d.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         }
         thumbIcon.setImageDrawable(d);
+    }
+
+    public void setAccentColor(int color)
+    {
+        color_accent = color;
+
+        if (frameEnd != null && frameStart != null)
+        {
+            if (activatedDirection == ACTIVATED_END) {
+                frameEnd.setBackgroundColor(color_accent);
+            } else frameStart.setBackgroundColor(color_accent);
+        }
+
+        if (allDragHintText != null)
+        {
+            for (TextView text : allDragHintText) {
+                if (text != null) {
+                    text.setTextColor(color);
+                }
+            }
+        }
+
+        if (allDragTargets != null)
+        {
+            for (View dragTarget : allDragTargets) {
+                if (dragTarget != null) {
+                    dragTarget.setBackgroundColor(color);
+                }
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
@@ -697,6 +697,7 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
             if (button != null) {
                 button.setThumbTextColor(buttonColors);
                 button.setThumbImageTint(colors.getColor(AlarmColorValues.COLOR_CONTROL_ENABLED));
+                button.setAccentColor(colors.getColor(AlarmColorValues.COLOR_CONTROL_PRESSED));
             }
         }
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
@@ -32,7 +32,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -867,8 +866,8 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
             if (isBrightMode)
             {
                 int snoozeBackgroundColor = colors.getColor(AlarmColorValues.COLOR_BRIGHT_BACKGROUND_START);
-                int snoozeTitleColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_PRIMARY, AlarmColorValues.COLOR_TEXT_PRIMARY_INVERSE);
-                int snoozeTimeColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_TIME, AlarmColorValues.COLOR_TEXT_TIME_INVERSE);
+                int snoozeTitleColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_PRIMARY_INVERSE, AlarmColorValues.COLOR_TEXT_PRIMARY);
+                int snoozeTimeColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_TIME_INVERSE, AlarmColorValues.COLOR_TEXT_TIME);
 
                 animateBackground(new int[] { currentBackgroundColor(), snoozeBackgroundColor }, 1500, new LinearInterpolator());
                 animateColors(new int[] { currentTitleColor(), snoozeTitleColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(alarmTitle));
@@ -944,11 +943,14 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
         }
     }
 
-    protected int getContrastingTextColor(int backgroundColor, ColorValues colors, String textColorID, String textColorInverseID)
+    protected static int getContrastingTextColor(int backgroundColor, ColorValues colors, String textColorID0, String textColorID1)
     {
-        int textColor = colors.getColor(textColorID);
-        int textInverseColor = colors.getColor(textColorInverseID);
-        return ColorUtils.isTextReadable(textColor, backgroundColor) ? textColor : textInverseColor;
+        int textColor0 = colors.getColor(textColorID0);
+        int textColor1 = colors.getColor(textColorID1);
+        double r0 = ColorUtils.getContrastRatio(textColor0, backgroundColor);
+        double r1 = ColorUtils.getContrastRatio(textColor1, backgroundColor);
+        return (r0 > r1) ? textColor0 : textColor1;
+        //return ColorUtils.isTextReadable(textColor0, backgroundColor) ? textColor0 : textColor1;
     }
 
     protected CharSequence formatTimeDisplay(Context context, Calendar calendar)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
@@ -32,6 +32,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -801,6 +802,15 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
             return colors.getColor(AlarmColorValues.COLOR_TEXT_TIME);
         }
     }
+    protected int currentTextColor()
+    {
+        if (clockText != null) {
+            return infoText.getCurrentTextColor();
+        } else {
+            return colors.getColor(AlarmColorValues.COLOR_TEXT_SECONDARY);
+        }
+    }
+
     protected int currentBackgroundColor()
     {
         Drawable d = background.getBackground();
@@ -868,10 +878,12 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
                 int snoozeBackgroundColor = colors.getColor(AlarmColorValues.COLOR_BRIGHT_BACKGROUND_START);
                 int snoozeTitleColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_PRIMARY_INVERSE, AlarmColorValues.COLOR_TEXT_PRIMARY);
                 int snoozeTimeColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_TIME_INVERSE, AlarmColorValues.COLOR_TEXT_TIME);
+                int snoozeTextColor = getContrastingTextColor(snoozeBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_SECONDARY_INVERSE, AlarmColorValues.COLOR_TEXT_SECONDARY);
 
                 animateBackground(new int[] { currentBackgroundColor(), snoozeBackgroundColor }, 1500, new LinearInterpolator());
                 animateColors(new int[] { currentTitleColor(), snoozeTitleColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(alarmTitle));
                 animateColors(new int[] { currentTimeColor(), snoozeTimeColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(clockText));
+                animateColors(new int[] { currentTextColor(), snoozeTextColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(infoText));
             }
 
             if (Build.VERSION.SDK_INT >= 17)  // BUG: on some older devices modifying brightness turns off the screen
@@ -901,10 +913,12 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
                 int timeoutBackgroundColor = colors.getColor(AlarmColorValues.COLOR_BRIGHT_BACKGROUND_START);
                 int timeoutTitleColor = getContrastingTextColor(timeoutBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_PRIMARY, AlarmColorValues.COLOR_TEXT_PRIMARY_INVERSE);
                 int timeoutTimeColor = getContrastingTextColor(timeoutBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_TIME, AlarmColorValues.COLOR_TEXT_TIME_INVERSE);
+                int timeoutTextColor = getContrastingTextColor(timeoutBackgroundColor, colors, AlarmColorValues.COLOR_TEXT_SECONDARY, AlarmColorValues.COLOR_TEXT_SECONDARY_INVERSE);
 
                 animateBackground(new int[] { currentBackgroundColor(), timeoutBackgroundColor }, 1500, new AccelerateInterpolator());
                 animateColors(new int[] { currentTitleColor(), timeoutTitleColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(alarmTitle));
                 animateColors(new int[] { currentTimeColor(), timeoutTimeColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(clockText));
+                animateColors(new int[] { currentTextColor(), timeoutTextColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(infoText));
             }
             setBrightness(WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE);
 
@@ -928,6 +942,7 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
                 animateBackground(new int[] { colors.getColor(AlarmColorValues.COLOR_BRIGHT_BACKGROUND_START), soundingBackgroundColor }, AlarmSettings.loadPrefAlarmBrightFadeIn(this), new AccelerateInterpolator());
                 animateColors(new int[] { currentTitleColor(), soundingTitleColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(alarmTitle));
                 animateColors(new int[] { currentTimeColor(), soundingTimeColor }, 1500, false, new LinearInterpolator(), new ColorableTextView(clockText));
+                infoText.setTextColor(Color.TRANSPARENT);
             }
             setBrightness(WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/AlarmDismissActivity.java
@@ -81,6 +81,7 @@ import com.forrestguice.suntimeswidget.settings.AppSettings;
 import com.forrestguice.suntimeswidget.settings.SolarEvents;
 import com.forrestguice.suntimeswidget.settings.WidgetSettings;
 import com.forrestguice.suntimeswidget.settings.WidgetThemes;
+import com.forrestguice.suntimeswidget.settings.colors.ColorUtils;
 import com.forrestguice.suntimeswidget.themes.SuntimesTheme;
 
 import java.util.ArrayList;
@@ -947,7 +948,7 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
     {
         int textColor = colors.getColor(textColorID);
         int textInverseColor = colors.getColor(textColorInverseID);
-        return isTextReadable(textColor, backgroundColor) ? textColor : textInverseColor;
+        return ColorUtils.isTextReadable(textColor, backgroundColor) ? textColor : textInverseColor;
     }
 
     protected CharSequence formatTimeDisplay(Context context, Calendar calendar)
@@ -1333,25 +1334,6 @@ public class AlarmDismissActivity extends AppCompatActivity implements AlarmDism
         }
     }
 
-    /**
-     * isTextReadable
-     * @param textColor text color
-     * @param backgroundColor background color
-     * @return contrast ratio between textColor and backgroundColor is greater than 4.5
-     */
-    public static boolean isTextReadable(int textColor, int backgroundColor) {
-        return getContrastRatio(textColor, backgroundColor) > 4.5;    // AA minimum; https://www.w3.org/TR/WCAG21/#contrast-minimum
-    }
-    public static double getLuminance(int color) {
-        return (0.2126 * Color.red(color) + 0.7152 * Color.green(color) + 0.0722 * Color.blue(color));
-    }
-    public static double getContrastRatio(int textColor, int backgroundColor)
-    {
-        double l_textColor = getLuminance(textColor);
-        double l_backgroundColor = getLuminance(backgroundColor);
-        double l1 = Math.max(l_textColor, l_backgroundColor);
-        double l2 = Math.min(l_textColor, l_backgroundColor);
-        return (l1 + 0.05) / (l2 + 0.05);
-    }
+
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
@@ -89,6 +89,17 @@ public class AlarmColorValues extends ResourceColorValues
                 R.string.configLabel_themeColorAccent, R.string.configLabel_alarms_text_disabledColor, R.string.configLabel_themeColorAction,
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_BACKGROUND, ROLE_BACKGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_TEXT, ROLE_TEXT,
+                ROLE_TEXT, ROLE_TEXT,
+                ROLE_TEXT, ROLE_TEXT,
+                ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.black, R.color.white,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
@@ -58,7 +58,7 @@ public class AlarmColorValues extends ResourceColorValues
 
     public String[] getColorKeys() {
         return new String[] {
-                COLOR_BRIGHT_BACKGROUND_START, COLOR_BRIGHT_BACKGROUND_END,
+                COLOR_BRIGHT_BACKGROUND_END, COLOR_BRIGHT_BACKGROUND_START,
                 COLOR_SOUNDING_PULSE_START, COLOR_SOUNDING_PULSE_END,
                 COLOR_SNOOZING_PULSE_START, COLOR_SNOOZING_PULSE_END,
                 COLOR_TEXT_PRIMARY, COLOR_TEXT_PRIMARY_INVERSE,
@@ -80,7 +80,7 @@ public class AlarmColorValues extends ResourceColorValues
     }
     public int[] getColorLabelsRes() {
         return new int[] {
-                R.string.configLabel_alarms_bg_startColor, R.string.configLabel_alarms_bg_endColor,
+                R.string.configLabel_alarms_bg_endColor, R.string.configLabel_alarms_bg_startColor,
                 R.string.configLabel_alarms_soundingPulse_startColor, R.string.configLabel_alarms_soundingPulse_endColor,
                 R.string.configLabel_alarms_snoozingPulse_startColor, R.string.configLabel_alarms_snoozingPulse_endColor,
                 R.string.configLabel_alarms_text_primaryColor, R.string.configLabel_alarms_text_primaryColorInverse,
@@ -91,18 +91,18 @@ public class AlarmColorValues extends ResourceColorValues
     }
     public int[] getColorRoles() {
         return new int[] {
-                ROLE_BACKGROUND_INVERSE, ROLE_BACKGROUND_PRIMARY,
+                ROLE_BACKGROUND_PRIMARY, ROLE_BACKGROUND_INVERSE,
                 ROLE_TEXT, ROLE_TEXT,
                 ROLE_TEXT_INVERSE, ROLE_TEXT_INVERSE,
                 ROLE_TEXT_PRIMARY, ROLE_TEXT_PRIMARY_INVERSE,
                 ROLE_TEXT, ROLE_TEXT_INVERSE,
-                ROLE_TEXT, ROLE_TEXT_INVERSE,
-                ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND
+                ROLE_TEXT_PRIMARY, ROLE_TEXT_PRIMARY_INVERSE,
+                ROLE_ACCENT, ROLE_FOREGROUND, ROLE_ACTION
         };
     }
     public int[] getColorsResDark() {
         return new int[] {
-                R.color.black, R.color.white,
+                R.color.white, R.color.black,
                 R.color.sunIcon_color_setting_dark, R.color.sunIcon_color_rising_dark,
                 R.color.dialog_bg_alt_dark, R.color.text_disabled_dark,
                 android.R.color.primary_text_dark, android.R.color.primary_text_light,
@@ -113,7 +113,7 @@ public class AlarmColorValues extends ResourceColorValues
     }
     public int[] getColorsResLight() {
         return new int[] {
-                R.color.black, R.color.white,
+                R.color.white, R.color.black,
                 R.color.sunIcon_color_setting_light, R.color.sunIcon_color_rising_light,
                 R.color.dialog_bg_alt_light, R.color.text_disabled_light,
                 android.R.color.primary_text_light, android.R.color.primary_text_dark,
@@ -124,7 +124,7 @@ public class AlarmColorValues extends ResourceColorValues
     }
     public int[] getColorsFallback() {
         return new int[] {
-                Color.BLACK, Color.WHITE,
+                Color.WHITE, Color.BLACK,
                 Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
                 Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
                 Color.WHITE, Color.BLACK,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
@@ -80,13 +80,13 @@ public class AlarmColorValues extends ResourceColorValues
     }
     public int[] getColorLabelsRes() {
         return new int[] {
-                0, 0,    // TODO: labels
-                0, 0,    // TODO: labels
-                0, 0,    // TODO: labels
-                0, 0,    // TODO: labels
-                0, 0,    // TODO: labels
-                0, 0,    // TODO: labels
-                0, 0, 0  // TODO: labels
+                R.string.configLabel_alarms_bg_startColor, R.string.configLabel_alarms_bg_endColor,
+                R.string.configLabel_alarms_soundingPulse_startColor, R.string.configLabel_alarms_soundingPulse_endColor,
+                R.string.configLabel_alarms_snoozingPulse_startColor, R.string.configLabel_alarms_snoozingPulse_endColor,
+                R.string.configLabel_alarms_text_primaryColor, R.string.configLabel_alarms_text_primaryColorInverse,
+                R.string.configLabel_alarms_text_secondaryColor, R.string.configLabel_alarms_text_secondaryColorInverse,
+                R.string.configLabel_alarms_text_timeColor, R.string.configLabel_alarms_text_timeColorInverse,
+                R.string.configLabel_themeColorAccent, R.string.configLabel_alarms_text_disabledColor, R.string.configLabel_themeColorAction,
         };
     }
     public int[] getColorsResDark() {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
@@ -91,12 +91,12 @@ public class AlarmColorValues extends ResourceColorValues
     }
     public int[] getColorRoles() {
         return new int[] {
-                ROLE_BACKGROUND, ROLE_BACKGROUND,
-                ROLE_FOREGROUND, ROLE_FOREGROUND,
-                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_BACKGROUND_INVERSE, ROLE_BACKGROUND_PRIMARY,
                 ROLE_TEXT, ROLE_TEXT,
-                ROLE_TEXT, ROLE_TEXT,
-                ROLE_TEXT, ROLE_TEXT,
+                ROLE_TEXT_INVERSE, ROLE_TEXT_INVERSE,
+                ROLE_TEXT_PRIMARY, ROLE_TEXT_PRIMARY_INVERSE,
+                ROLE_TEXT, ROLE_TEXT_INVERSE,
+                ROLE_TEXT, ROLE_TEXT_INVERSE,
                 ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND
         };
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/AlarmColorValues.java
@@ -1,0 +1,160 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock.ui.colors;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.os.Parcel;
+
+import com.forrestguice.suntimeswidget.R;
+import com.forrestguice.suntimeswidget.colors.ColorValues;
+import com.forrestguice.suntimeswidget.colors.ResourceColorValues;
+
+/**
+ * AlarmColorValues
+ */
+public class AlarmColorValues extends ResourceColorValues
+{
+    public static final String TAG_ALARMCOLORS = "alarmcolors";
+
+    public static final String COLOR_SOUNDING_PULSE_START = "color_sounding_pulse_start";
+    public static final String COLOR_SOUNDING_PULSE_END = "color_sounding_pulse_end";
+
+    public static final String COLOR_SNOOZING_PULSE_START = "color_snoozing_pulse_start";
+    public static final String COLOR_SNOOZING_PULSE_END = "color_snoozing_pulse_end";
+
+    public static final String COLOR_BRIGHT_BACKGROUND_START = "color_bright_bg_start";
+    public static final String COLOR_BRIGHT_BACKGROUND_END = "color_bright_bg_end";
+
+    public static final String COLOR_TEXT_PRIMARY = "color_text_primary";
+    public static final String COLOR_TEXT_PRIMARY_INVERSE = "color_text_primary_inverse";
+
+    public static final String COLOR_TEXT_SECONDARY = "color_text_secondary";
+    public static final String COLOR_TEXT_SECONDARY_INVERSE = "color_text_secondary_inverse";
+
+    public static final String COLOR_TEXT_TIME = "color_text_time";
+    public static final String COLOR_TEXT_TIME_INVERSE = "color_text_time_inverse";
+
+    public static final String COLOR_CONTROL_ENABLED = "color_control_enabled";
+    public static final String COLOR_CONTROL_DISABLED = "color_control_disabled";
+    public static final String COLOR_CONTROL_PRESSED = "color_control_pressed";
+
+    public String[] getColorKeys() {
+        return new String[] {
+                COLOR_BRIGHT_BACKGROUND_START, COLOR_BRIGHT_BACKGROUND_END,
+                COLOR_SOUNDING_PULSE_START, COLOR_SOUNDING_PULSE_END,
+                COLOR_SNOOZING_PULSE_START, COLOR_SNOOZING_PULSE_END,
+                COLOR_TEXT_PRIMARY, COLOR_TEXT_PRIMARY_INVERSE,
+                COLOR_TEXT_SECONDARY, COLOR_TEXT_SECONDARY_INVERSE,
+                COLOR_TEXT_TIME, COLOR_TEXT_TIME_INVERSE,
+                COLOR_CONTROL_ENABLED, COLOR_CONTROL_DISABLED, COLOR_CONTROL_PRESSED
+        };
+    }
+    public int[] getColorAttrs() {
+        return new int[] {
+                0, 0,
+                R.attr.sunsetColor, R.attr.sunriseColor,                // sounding pulse
+                R.attr.dialogBackgroundAlt, R.attr.text_disabledColor,  // snoozing pulse
+                android.R.attr.textColorPrimary, android.R.attr.textColorPrimaryInverse,
+                android.R.attr.textColorSecondary,  android.R.attr.textColorSecondaryInverse,
+                android.R.attr.textColorPrimary, android.R.attr.textColorPrimaryInverse,
+                R.attr.buttonPressColor, R.attr.text_disabledColor, R.attr.buttonPressColor
+        };
+    }
+    public int[] getColorLabelsRes() {
+        return new int[] {
+                0, 0,    // TODO: labels
+                0, 0,    // TODO: labels
+                0, 0,    // TODO: labels
+                0, 0,    // TODO: labels
+                0, 0,    // TODO: labels
+                0, 0,    // TODO: labels
+                0, 0, 0  // TODO: labels
+        };
+    }
+    public int[] getColorsResDark() {
+        return new int[] {
+                R.color.black, R.color.white,
+                R.color.sunIcon_color_setting_dark, R.color.sunIcon_color_rising_dark,
+                R.color.dialog_bg_alt_dark, R.color.text_disabled_dark,
+                android.R.color.primary_text_dark, android.R.color.primary_text_light,
+                android.R.color.secondary_text_dark, android.R.color.secondary_text_light,
+                android.R.color.primary_text_dark, android.R.color.primary_text_light,
+                R.color.text_accent_dark, R.color.text_disabled_dark, R.color.text_accent_dark
+        };
+    }
+    public int[] getColorsResLight() {
+        return new int[] {
+                R.color.black, R.color.white,
+                R.color.sunIcon_color_setting_light, R.color.sunIcon_color_rising_light,
+                R.color.dialog_bg_alt_light, R.color.text_disabled_light,
+                android.R.color.primary_text_light, android.R.color.primary_text_dark,
+                android.R.color.secondary_text_light, android.R.color.secondary_text_dark,
+                android.R.color.primary_text_light, android.R.color.primary_text_dark,
+                R.color.text_accent_light, R.color.text_disabled_light, R.color.text_accent_light
+        };
+    }
+    public int[] getColorsFallback() {
+        return new int[] {
+                Color.BLACK, Color.WHITE,
+                Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
+                Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.CYAN, Color.MAGENTA, Color.CYAN
+        };
+    }
+
+    public AlarmColorValues(ColorValues other) {
+        super(other);
+    }
+    public AlarmColorValues(SharedPreferences prefs, String prefix) {
+        super(prefs, prefix);
+    }
+    protected AlarmColorValues(Parcel in) {
+        super(in);
+    }
+    public AlarmColorValues() {
+        super();
+    }
+
+    public AlarmColorValues(Context context, boolean fallbackDarkTheme) {
+        super(context, fallbackDarkTheme);
+    }
+
+    public AlarmColorValues(String jsonString) {
+        super(jsonString);
+    }
+
+    public static final Creator<AlarmColorValues> CREATOR = new Creator<AlarmColorValues>()
+    {
+        public AlarmColorValues createFromParcel(Parcel in) {
+            return new AlarmColorValues(in);
+        }
+        public AlarmColorValues[] newArray(int size) {
+            return new AlarmColorValues[size];
+        }
+    };
+
+    public static AlarmColorValues getColorDefaults(Context context, boolean darkTheme) {
+        return new AlarmColorValues(new AlarmColorValues().getDefaultValues(context, darkTheme));
+    }
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues.java
@@ -43,7 +43,7 @@ public class BrightAlarmColorValues extends AlarmColorValues
     @Override
     public int[] getColorsResLight() {
         return new int[] {
-                R.color.black, R.color.white,
+                R.color.white, R.color.black,
                 R.color.sunIcon_color_setting_light, R.color.sunIcon_color_rising_light,
                 R.color.dialog_bg_alt_light, R.color.text_disabled_light,
                 android.R.color.primary_text_light, android.R.color.primary_text_dark,
@@ -55,7 +55,7 @@ public class BrightAlarmColorValues extends AlarmColorValues
     @Override
     public int[] getColorsFallback() {
         return new int[] {
-                Color.BLACK, Color.WHITE,
+                Color.WHITE, Color.BLACK,
                 Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
                 Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
                 Color.WHITE, Color.BLACK,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues.java
@@ -1,0 +1,67 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock.ui.colors;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import com.forrestguice.suntimeswidget.R;
+
+/**
+ * BrightAlarmColorValues
+ */
+public class BrightAlarmColorValues extends AlarmColorValues
+{
+    public BrightAlarmColorValues(Context context, boolean fallbackDarkTheme) {
+        super(context, fallbackDarkTheme);
+    }
+
+    @Override
+    public int[] getColorAttrs() {
+        return new int[ getColorKeys().length ];    // 0 ... skip attrs
+    }
+    @Override
+    public int[] getColorsResDark() {
+        return getColorsResLight();    // dark/light colors are the same
+    }
+    @Override
+    public int[] getColorsResLight() {
+        return new int[] {
+                R.color.black, R.color.white,
+                R.color.sunIcon_color_setting_light, R.color.sunIcon_color_rising_light,
+                R.color.dialog_bg_alt_light, R.color.text_disabled_light,
+                android.R.color.primary_text_light, android.R.color.primary_text_dark,
+                android.R.color.secondary_text_light, android.R.color.secondary_text_dark,
+                android.R.color.primary_text_light, android.R.color.primary_text_dark,
+                R.color.text_accent_light, R.color.text_disabled_light, R.color.text_accent_light
+        };
+    }
+    @Override
+    public int[] getColorsFallback() {
+        return new int[] {
+                Color.BLACK, Color.WHITE,
+                Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
+                Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.CYAN, Color.MAGENTA, Color.CYAN
+        };
+    }
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValuesCollection.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValuesCollection.java
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock.ui.colors;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.forrestguice.suntimeswidget.colors.ColorValues;
+import com.forrestguice.suntimeswidget.colors.ColorValuesCollection;
+import com.forrestguice.suntimeswidget.settings.PrefTypeInfo;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * ColorValuesCollection
+ */
+public class BrightAlarmColorValuesCollection<T> extends ColorValuesCollection<ColorValues>
+{
+    public static final String PREFS_BRIGHTALARM_COLORS = "prefs_brightalarm";
+
+    private static final String PREFS_PREFIX = "app_";
+    private static final String PREFS_COLLECTION_PREFIX = "brightalarm_";
+
+    public BrightAlarmColorValuesCollection() {
+        super();
+    }
+    public BrightAlarmColorValuesCollection(Context context) {
+        super(context);
+    }
+    protected BrightAlarmColorValuesCollection(Parcel in) {
+        super(in);
+    }
+
+    @Override
+    @NonNull
+    protected String getSharedPrefsPrefix() {
+        return PREFS_PREFIX;
+    }
+
+    @NonNull
+    protected String getCollectionSharedPrefsPrefix() {
+        return PREFS_COLLECTION_PREFIX;
+    }
+
+    @Nullable
+    @Override
+    public String getSharedPrefsName() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getCollectionSharedPrefsName() {
+        return PREFS_BRIGHTALARM_COLORS;
+    }
+
+    @Override
+    public ColorValues getDefaultColors(Context context) {
+        return new BrightAlarmColorValues(context,  true);
+    }
+
+    public static final Creator<BrightAlarmColorValuesCollection> CREATOR = new Creator<BrightAlarmColorValuesCollection>()
+    {
+        public BrightAlarmColorValuesCollection createFromParcel(Parcel in) {
+            return new BrightAlarmColorValuesCollection<ColorValues>(in);
+        }
+        public BrightAlarmColorValuesCollection<ColorValues>[] newArray(int size) {
+            return new BrightAlarmColorValuesCollection[size];
+        }
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public static final String[] ALL_KEYS = new String[] {
+            PREFS_PREFIX + "0" + "_" + KEY_SELECTED, PREFS_PREFIX + "1" + "_" + KEY_SELECTED,
+            PREFS_PREFIX + "0" + "_" + KEY_SELECTED + "_" + AlarmColorValues.TAG_ALARMCOLORS,
+            PREFS_PREFIX + "1" + "_" + KEY_SELECTED + "_" + AlarmColorValues.TAG_ALARMCOLORS,
+    };
+
+    private static Map<String,Class> types = null;
+    public static Map<String,Class> getPrefTypes()
+    {
+        if (types == null)
+        {
+            types = new TreeMap<>();
+            for (String key : ALL_KEYS) {
+                if (!types.containsKey(key)) {
+                    types.put(key, String.class);
+                }
+            }
+        }
+        return types;
+    }
+
+    public static PrefTypeInfo getPrefTypeInfo()
+    {
+        return new PrefTypeInfo()
+        {
+            public String[] allKeys() {
+                return ALL_KEYS;
+            }
+            public String[] intKeys() {
+                return new String[0];
+            }
+            public String[] longKeys() {
+                return new String[0];
+            }
+            public String[] floatKeys() {
+                return new String[0];
+            }
+            public String[] boolKeys() {
+                return new String[0];
+            }
+        };
+    }
+
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValuesCollection.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValuesCollection.java
@@ -24,6 +24,7 @@ import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.colors.ColorValues;
 import com.forrestguice.suntimeswidget.colors.ColorValuesCollection;
 import com.forrestguice.suntimeswidget.settings.PrefTypeInfo;
@@ -132,6 +133,59 @@ public class BrightAlarmColorValuesCollection<T> extends ColorValuesCollection<C
                 return new String[0];
             }
         };
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public static final String DEFAULT_SUNRISE = "sunrise";
+    public static final String DEFAULT_FOLIAGE = "foliage";
+
+    @Override
+    protected String[] getDefaultColorIDs() {
+        return new String[] { DEFAULT_SUNRISE, DEFAULT_FOLIAGE };
+    }
+    @Override
+    protected ColorValues getDefaultColors(Context context, @Nullable String colorsID)
+    {
+        if (colorsID == null) {
+            return getDefaultColors(context);
+        }
+
+        ColorValues v;
+        switch (colorsID)
+        {
+            case DEFAULT_SUNRISE:
+                v = new BrightAlarmColorValues_Sunrise(context, true);
+                break;
+
+            case DEFAULT_FOLIAGE:
+                v = new BrightAlarmColorValues_Foliage(context, true);
+                break;
+
+            default:
+                v = getDefaultColors(context);
+                break;
+        }
+        v.setID(colorsID);
+        v.setLabel(getDefaultLabel(context, colorsID));
+        return v;
+    }
+    public String getDefaultLabel(Context context, @Nullable String colorsID)
+    {
+        if (colorsID == null) {
+            return context.getString(R.string.brightMode_colors_label_default);
+        }
+        switch(colorsID)
+        {
+            case DEFAULT_SUNRISE:
+                return context.getString(R.string.brightMode_colors_label_sunrise);
+
+            case DEFAULT_FOLIAGE:
+                return context.getString(R.string.brightMode_colors_label_foliage);
+
+            default:
+                return colorsID;
+        }
     }
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValuesCollection.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValuesCollection.java
@@ -137,12 +137,13 @@ public class BrightAlarmColorValuesCollection<T> extends ColorValuesCollection<C
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    public static final String DEFAULT_SUNRISE = "sunrise";
-    public static final String DEFAULT_FOLIAGE = "foliage";
+    public static final String DEFAULT_ID_SUNRISE = "sunrise";
+    public static final String DEFAULT_ID_FOLIAGE = "foliage";
+    public static final String DEFAULT_ID_BLUESKY = "bluesky";
 
     @Override
     protected String[] getDefaultColorIDs() {
-        return new String[] { DEFAULT_SUNRISE, DEFAULT_FOLIAGE };
+        return new String[] { DEFAULT_ID_SUNRISE, DEFAULT_ID_FOLIAGE, DEFAULT_ID_BLUESKY};
     }
     @Override
     protected ColorValues getDefaultColors(Context context, @Nullable String colorsID)
@@ -154,12 +155,16 @@ public class BrightAlarmColorValuesCollection<T> extends ColorValuesCollection<C
         ColorValues v;
         switch (colorsID)
         {
-            case DEFAULT_SUNRISE:
+            case DEFAULT_ID_SUNRISE:
                 v = new BrightAlarmColorValues_Sunrise(context, true);
                 break;
 
-            case DEFAULT_FOLIAGE:
+            case DEFAULT_ID_FOLIAGE:
                 v = new BrightAlarmColorValues_Foliage(context, true);
+                break;
+
+            case DEFAULT_ID_BLUESKY:
+                v = new BrightAlarmColorValues_BlueSky(context, true);
                 break;
 
             default:
@@ -177,11 +182,14 @@ public class BrightAlarmColorValuesCollection<T> extends ColorValuesCollection<C
         }
         switch(colorsID)
         {
-            case DEFAULT_SUNRISE:
+            case DEFAULT_ID_SUNRISE:
                 return context.getString(R.string.brightMode_colors_label_sunrise);
 
-            case DEFAULT_FOLIAGE:
+            case DEFAULT_ID_FOLIAGE:
                 return context.getString(R.string.brightMode_colors_label_foliage);
+
+            case DEFAULT_ID_BLUESKY:
+                return context.getString(R.string.brightMode_colors_label_bluesky);
 
             default:
                 return colorsID;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues_BlueSky.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues_BlueSky.java
@@ -1,0 +1,67 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock.ui.colors;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import com.forrestguice.suntimeswidget.R;
+
+/**
+ * BrightAlarmColorValues
+ */
+public class BrightAlarmColorValues_BlueSky extends BrightAlarmColorValues
+{
+    public BrightAlarmColorValues_BlueSky(Context context, boolean fallbackDarkTheme) {
+        super(context, fallbackDarkTheme);
+    }
+
+    @Override
+    public int[] getColorAttrs() {
+        return new int[ getColorKeys().length ];    // 0 ... skip attrs
+    }
+    @Override
+    public int[] getColorsResDark() {
+        return getColorsResLight();    // dark/light colors are the same
+    }
+    @Override
+    public int[] getColorsResLight() {
+        return new int[] {
+                R.color.cyan_a100, R.color.blue_grey_999,
+                R.color.blue_a200, R.color.white,
+                R.color.grey_50, R.color.light_text_disabled,
+                R.color.light_text_medium, R.color.dark_text_medium,
+                R.color.light_text_medium, R.color.dark_text_medium,
+                R.color.light_text_medium, R.color.dark_text_high,
+                R.color.indigo_a700, R.color.light_text_disabled, R.color.indigo_a700
+        };
+    }
+    @Override
+    public int[] getColorsFallback() {
+        return new int[] {
+                Color.WHITE, Color.BLACK,
+                Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
+                Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.CYAN, Color.MAGENTA, Color.CYAN
+        };
+    }
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues_Foliage.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues_Foliage.java
@@ -1,0 +1,67 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock.ui.colors;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import com.forrestguice.suntimeswidget.R;
+
+/**
+ * BrightAlarmColorValues
+ */
+public class BrightAlarmColorValues_Foliage extends BrightAlarmColorValues
+{
+    public BrightAlarmColorValues_Foliage(Context context, boolean fallbackDarkTheme) {
+        super(context, fallbackDarkTheme);
+    }
+
+    @Override
+    public int[] getColorAttrs() {
+        return new int[ getColorKeys().length ];    // 0 ... skip attrs
+    }
+    @Override
+    public int[] getColorsResDark() {
+        return getColorsResLight();    // dark/light colors are the same
+    }
+    @Override
+    public int[] getColorsResLight() {
+        return new int[] {
+                R.color.light_green_a100, R.color.brown_999,
+                R.color.light_green_800, R.color.lime_600,
+                R.color.grey_50, R.color.light_text_disabled,
+                R.color.light_text_medium, R.color.dark_text_medium,
+                R.color.light_text_medium, R.color.dark_text_medium,
+                R.color.light_text_medium, R.color.dark_text_high,
+                R.color.green_800, R.color.light_text_disabled, R.color.green_800
+        };
+    }
+    @Override
+    public int[] getColorsFallback() {
+        return new int[] {
+                Color.WHITE, Color.BLACK,
+                Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
+                Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.CYAN, Color.MAGENTA, Color.CYAN
+        };
+    }
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues_Sunrise.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/ui/colors/BrightAlarmColorValues_Sunrise.java
@@ -1,0 +1,67 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock.ui.colors;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import com.forrestguice.suntimeswidget.R;
+
+/**
+ * BrightAlarmColorValues
+ */
+public class BrightAlarmColorValues_Sunrise extends BrightAlarmColorValues
+{
+    public BrightAlarmColorValues_Sunrise(Context context, boolean fallbackDarkTheme) {
+        super(context, fallbackDarkTheme);
+    }
+
+    @Override
+    public int[] getColorAttrs() {
+        return new int[ getColorKeys().length ];    // 0 ... skip attrs
+    }
+    @Override
+    public int[] getColorsResDark() {
+        return getColorsResLight();    // dark/light colors are the same
+    }
+    @Override
+    public int[] getColorsResLight() {
+        return new int[] {
+                R.color.amber_a200, R.color.blue_grey_999,
+                R.color.deep_orange_a700, R.color.yellow_a400,
+                R.color.grey_50, R.color.light_text_disabled,
+                R.color.light_text_medium, R.color.dark_text_medium,
+                R.color.light_text_medium, R.color.dark_text_medium,
+                R.color.light_text_medium, R.color.dark_text_high,
+                R.color.indigo_a200, R.color.light_text_disabled, R.color.indigo_a200
+        };
+    }
+    @Override
+    public int[] getColorsFallback() {
+        return new int[] {
+                Color.WHITE, Color.BLACK,
+                Color.parseColor("#ff9900"), Color.parseColor("#ffd500"),
+                Color.parseColor("#ff212121"), Color.parseColor("#ff9e9e9e"),
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.WHITE, Color.BLACK,
+                Color.CYAN, Color.MAGENTA, Color.CYAN
+        };
+    }
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/cards/CardColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/cards/CardColorValues.java
@@ -77,6 +77,15 @@ public class CardColorValues extends ResourceColorValues implements Parcelable
                 R.string.configLabel_themeColorGraphSunFill, R.string.configLabel_themeColorGraphSunStroke
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_FOREGROUND, ROLE_TEXT,
+                ROLE_FOREGROUND, ROLE_TEXT,
+                ROLE_FOREGROUND, ROLE_TEXT,
+                ROLE_FOREGROUND, ROLE_TEXT,
+                ROLE_FOREGROUND, ROLE_FOREGROUND
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.sunIcon_color_rising_dark, R.color.table_rising_dark,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/AppColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/AppColorValues.java
@@ -83,6 +83,7 @@ public class AppColorValues extends ResourceColorValues
     }
 
     protected static String[] colorKeys;
+    protected static final int[] colorRoles;
     protected static final int[] colorAttrs;
     protected static final int[] colorResDark;
     protected static final int[] colorResLight;
@@ -92,6 +93,7 @@ public class AppColorValues extends ResourceColorValues
     static
     {
         ArrayList<String> keys = new ArrayList<>();
+        ArrayList<Integer> roleList = new ArrayList<>();
         ArrayList<Integer> attrs = new ArrayList<>();
         ArrayList<Integer> darkRes = new ArrayList<>();
         ArrayList<Integer> lightRes = new ArrayList<>();
@@ -134,6 +136,13 @@ public class AppColorValues extends ResourceColorValues
                 }
             }
 
+            int[] roles = r[i].getColorRoles();
+            for (int j=0; j<roles.length; j++) {
+                if (!keySet.contains(s[j])) {
+                    roleList.add(roles[j]);
+                }
+            }
+
             int[] f = r[i].getColorsFallback();
             for (int j=0; j<f.length; j++) {
                 if (!keySet.contains(s[j])) {
@@ -152,6 +161,7 @@ public class AppColorValues extends ResourceColorValues
         }
 
         colorKeys = keys.toArray(new String[0]);
+        colorRoles = toIntArray(roleList);
         colorAttrs = toIntArray(attrs);
         colorResDark = toIntArray(darkRes);
         colorResLight = toIntArray(lightRes);
@@ -168,6 +178,12 @@ public class AppColorValues extends ResourceColorValues
     public int[] getColorLabelsRes() {
         return colorResLabel;
     }
+
+    @Override
+    public int[] getColorRoles() {
+        return colorRoles;
+    }
+
     public int[] getColorsResDark() {
         return colorResDark;
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
@@ -177,8 +177,13 @@ public abstract class ColorValues implements Parcelable
 
     public static final int ROLE_UNKNOWN = 0;
     public static final int ROLE_BACKGROUND = 100;
+    public static final int ROLE_BACKGROUND_PRIMARY = 125;
+    public static final int ROLE_BACKGROUND_INVERSE = 150;
     public static final int ROLE_FOREGROUND = 200;
     public static final int ROLE_TEXT = 300;
+    public static final int ROLE_TEXT_INVERSE = 325;
+    public static final int ROLE_TEXT_PRIMARY = 350;
+    public static final int ROLE_TEXT_PRIMARY_INVERSE = 375;
 
     public static final String SUFFIX_ROLE = "_ROLE";
     public void setRole(String key, int role) {
@@ -190,6 +195,16 @@ public abstract class ColorValues implements Parcelable
     }
     public boolean hasRole(String key) {
         return values.containsKey(key + SUFFIX_ROLE);
+    }
+    @Nullable
+    public String findColorWithRole(int role)
+    {
+        for (String key : values.keySet()) {
+            if (getRole(key) == role) {
+                return key;
+            }
+        }
+        return null;
     }
 
     public void setColor(String key, int color) {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
@@ -58,6 +58,7 @@ public abstract class ColorValues implements Parcelable
     public void loadColorValues(@NonNull Parcel in)
     {
         setID(in.readString());
+        setLabel(in.readString());
         for (String key : getColorKeys())
         {
             setColor(key, in.readInt());
@@ -68,6 +69,7 @@ public abstract class ColorValues implements Parcelable
     public void writeToParcel(Parcel dest, int flags)
     {
         dest.writeString(getID());
+        dest.writeString(getLabel());
         for (String key : getColorKeys())
         {
             dest.writeInt(values.getAsInteger(key));
@@ -78,6 +80,7 @@ public abstract class ColorValues implements Parcelable
     public void loadColorValues(@NonNull ColorValues other)
     {
         setID(other.getID());
+        setLabel(other.getLabel());
         for (String key : other.getColorKeys())
         {
             setColor(key, other.getColor(key));
@@ -90,6 +93,7 @@ public abstract class ColorValues implements Parcelable
     public void loadColorValues(@NonNull ContentValues values)
     {
         setID(values.getAsString(KEY_ID));
+        setLabel(values.getAsString(KEY_LABEL));
         for (String key : getColorKeys())
         {
             setColor(key, values.getAsInteger(key));
@@ -101,10 +105,18 @@ public abstract class ColorValues implements Parcelable
 
     public void loadColorValues(SharedPreferences prefs, String prefix)
     {
-        setID(prefs.getString(prefix + KEY_ID, null));
+        setID(loadColorValuesID(prefs, prefix));
+        setLabel(loadColorValuesLabel(prefs, prefix));
         for (String key : getColorKeys()) {
             setColor(key, prefs.getInt(prefix + key, getFallbackColor()));
         }
+    }
+    public static String loadColorValuesID(SharedPreferences prefs, String prefix) {
+        return prefs.getString(prefix + KEY_ID, null);
+    }
+    public static String loadColorValuesLabel(SharedPreferences prefs, String prefix) {
+        Log.d("DEBUG", "loadColorValuesLabel: prefix: " + prefix);
+        return prefs.getString(prefix + KEY_LABEL, null);
     }
 
     public boolean loadColorValues(String jsonString)
@@ -112,6 +124,7 @@ public abstract class ColorValues implements Parcelable
         try {
             JSONObject json = new JSONObject(jsonString);
             setID(json.getString(KEY_ID));
+            setLabel(json.getString(KEY_LABEL));
             for (String key : getColorKeys())
             {
                 setColor(key, json.has(key) ? Color.parseColor(json.getString(key).trim()) : getFallbackColor());
@@ -131,6 +144,7 @@ public abstract class ColorValues implements Parcelable
     {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putString(prefix + KEY_ID, getID());
+        editor.putString(prefix + KEY_LABEL, getLabel());
         for (String key : getColorKeys()) {
             editor.putInt(prefix + key, values.getAsInteger(key));
         }
@@ -144,6 +158,7 @@ public abstract class ColorValues implements Parcelable
     {
         SharedPreferences.Editor editor = prefs.edit();
         editor.remove(prefix + KEY_ID);
+        editor.remove(prefix + KEY_LABEL);
         for (String key : getColorKeys()) {
             editor.remove(prefix + key);
         }
@@ -161,6 +176,16 @@ public abstract class ColorValues implements Parcelable
     }
     public String getID() {
         return values.getAsString(KEY_ID);
+    }
+
+    public static final String KEY_LABEL = "colorValuesLabel";
+    public void setLabel( String colorsLabel ) {
+        values.put(KEY_LABEL, colorsLabel);
+    }
+    public String getLabel()
+    {
+        String label = values.getAsString(KEY_LABEL);
+        return (label != null) ? label : getID();
     }
 
     public static final String SUFFIX_LABEL = "_LABEL";
@@ -264,6 +289,7 @@ public abstract class ColorValues implements Parcelable
         JSONObject result = new JSONObject();
         try {
             result.put(KEY_ID, getID());
+            result.put(KEY_LABEL, getLabel());
             for (String key : getColorKeys())
             {
                 result.put(key, "#" + Integer.toHexString(getColor(key)));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
@@ -118,6 +118,19 @@ public abstract class ColorValues implements Parcelable
         Log.d("DEBUG", "loadColorValuesLabel: prefix: " + prefix);
         return prefs.getString(prefix + KEY_LABEL, null);
     }
+    public static int loadColorValuesColor(SharedPreferences prefs, String prefix, String key, int defaultColor) {
+        return prefs.getInt(prefix + key, defaultColor);
+    }
+    public static int[] loadColorValuesColors(SharedPreferences prefs, String prefix, int defaultColor, String... keys)
+    {
+        int[] retValue = new int[keys != null ? keys.length : 0];
+        if (keys != null) {
+            for (int i=0; i<retValue.length; i++) {
+                retValue[i] = prefs.getInt(prefix + keys[i], defaultColor);
+            }
+        }
+        return retValue;
+    }
 
     public boolean loadColorValues(String jsonString)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
@@ -184,6 +184,8 @@ public abstract class ColorValues implements Parcelable
     public static final int ROLE_TEXT_INVERSE = 325;
     public static final int ROLE_TEXT_PRIMARY = 350;
     public static final int ROLE_TEXT_PRIMARY_INVERSE = 375;
+    public static final int ROLE_ACCENT = 400;
+    public static final int ROLE_ACTION = 500;
 
     public static final String SUFFIX_ROLE = "_ROLE";
     public void setRole(String key, int role) {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValues.java
@@ -175,6 +175,23 @@ public abstract class ColorValues implements Parcelable
         return values.containsKey(key + SUFFIX_LABEL);
     }
 
+    public static final int ROLE_UNKNOWN = 0;
+    public static final int ROLE_BACKGROUND = 100;
+    public static final int ROLE_FOREGROUND = 200;
+    public static final int ROLE_TEXT = 300;
+
+    public static final String SUFFIX_ROLE = "_ROLE";
+    public void setRole(String key, int role) {
+        values.put(key + SUFFIX_ROLE, role);
+    }
+    public int getRole(String key) {
+        Integer role = values.getAsInteger(key + SUFFIX_ROLE);
+        return (role != null ? role : ROLE_UNKNOWN);
+    }
+    public boolean hasRole(String key) {
+        return values.containsKey(key + SUFFIX_ROLE);
+    }
+
     public void setColor(String key, int color) {
         values.put(key, color);
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollection.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollection.java
@@ -21,6 +21,7 @@ package com.forrestguice.suntimeswidget.colors;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
@@ -212,10 +213,10 @@ public abstract class ColorValuesCollection<T extends ColorValues> implements Pa
     public String getSelectedColorsLabel(Context context, int appWidgetID, @Nullable String tag)
     {
         String colorsID = getSelectedColorsID(context, appWidgetID, tag);
-        return getLabel(context, colorsID);
+        return getColorsLabel(context, colorsID);
     }
     @Nullable
-    public String getLabel(Context context, @Nullable String colorsID)
+    public String getColorsLabel(Context context, @Nullable String colorsID)
     {
         if (colorsID != null)
         {
@@ -224,6 +225,17 @@ public abstract class ColorValuesCollection<T extends ColorValues> implements Pa
             return ColorValues.loadColorValuesLabel(prefs, prefix);
 
         } else return null;
+    }
+    @Nullable
+    public int[] getColors(Context context, @Nullable String colorsID, int defaultValue, String... keys)
+    {
+        if (colorsID != null)
+        {
+            SharedPreferences prefs = getCollectionSharedPreferences(context);
+            String prefix = getCollectionSharedPrefsPrefix() + colorsID + "_";
+            return ColorValues.loadColorValuesColors(prefs, prefix, defaultValue, keys);
+
+        } else return new int[] { defaultValue };
     }
 
     @Nullable

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollection.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollection.java
@@ -175,7 +175,7 @@ public abstract class ColorValuesCollection<T extends ColorValues> implements Pa
     @Nullable
     public String getSelectedColorsID(Context context, int appWidgetID, @Nullable String tag) {
         SharedPreferences prefs = getSharedPreferences(context);
-        return prefs.getString(getSharedPrefsPrefix() + appWidgetID + "_" + KEY_SELECTED + ((tag != null) ? ("_" + tag) : ""), null);
+        return prefs.getString(getSelectedColorsKey(appWidgetID, tag), null);
     }
 
     public void setSelectedColorsID(Context context, @Nullable String colorsID) {
@@ -187,7 +187,7 @@ public abstract class ColorValuesCollection<T extends ColorValues> implements Pa
     public void setSelectedColorsID(Context context, @Nullable String colorsID, int appWidgetID, @Nullable String tag)
     {
         SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-        editor.putString(getSharedPrefsPrefix() + appWidgetID + "_" + KEY_SELECTED + ((tag != null) ? ("_" + tag) : ""), colorsID);
+        editor.putString(getSelectedColorsKey(appWidgetID, tag), colorsID);
         editor.apply();
     }
 
@@ -200,8 +200,12 @@ public abstract class ColorValuesCollection<T extends ColorValues> implements Pa
     public void clearSelectedColorsID(Context context, int appWidgetID, @Nullable String tag)
     {
         SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-        editor.remove(getSharedPrefsPrefix() + appWidgetID + "_" + KEY_SELECTED + ((tag != null) ? ("_" + tag) : ""));
+        editor.remove(getSelectedColorsKey(appWidgetID, tag));
         editor.apply();
+    }
+
+    public String getSelectedColorsKey(int appWidgetID, @Nullable String tag) {
+        return getSharedPrefsPrefix() + appWidgetID + "_" + KEY_SELECTED + ((tag != null) ? ("_" + tag) : "");
     }
 
     @Nullable

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollection.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollection.java
@@ -209,6 +209,24 @@ public abstract class ColorValuesCollection<T extends ColorValues> implements Pa
     }
 
     @Nullable
+    public String getSelectedColorsLabel(Context context, int appWidgetID, @Nullable String tag)
+    {
+        String colorsID = getSelectedColorsID(context, appWidgetID, tag);
+        return getLabel(context, colorsID);
+    }
+    @Nullable
+    public String getLabel(Context context, @Nullable String colorsID)
+    {
+        if (colorsID != null)
+        {
+            SharedPreferences prefs = getCollectionSharedPreferences(context);
+            String prefix = getCollectionSharedPrefsPrefix() + colorsID + "_";
+            return ColorValues.loadColorValuesLabel(prefs, prefix);
+
+        } else return null;
+    }
+
+    @Nullable
     public abstract String getSharedPrefsName();
     public SharedPreferences getSharedPreferences(Context context)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollectionPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollectionPreference.java
@@ -16,7 +16,7 @@
     along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package com.forrestguice.suntimeswidget.settings.colors;
+package com.forrestguice.suntimeswidget.colors;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -29,34 +29,31 @@ import android.util.Log;
 import android.view.View;
 
 import com.forrestguice.suntimeswidget.R;
-import com.forrestguice.suntimeswidget.colors.ColorValues;
-import com.forrestguice.suntimeswidget.colors.ColorValuesCollection;
-import com.forrestguice.suntimeswidget.colors.ColorValuesSheetActivity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class ColorCollectionPreference extends Preference
+public class ColorValuesCollectionPreference extends Preference
 {
-    public ColorCollectionPreference(Context context) {
+    public ColorValuesCollectionPreference(Context context) {
         super(context);
     }
 
-    public ColorCollectionPreference(Context context, AttributeSet attrs)
+    public ColorValuesCollectionPreference(Context context, AttributeSet attrs)
     {
         super(context, attrs);
         setParams(context, attrs);
     }
 
     @TargetApi(21)
-    public ColorCollectionPreference(Context context, AttributeSet attrs, int defStyleAttr)
+    public ColorValuesCollectionPreference(Context context, AttributeSet attrs, int defStyleAttr)
     {
         super(context, attrs, defStyleAttr);
         setParams(context, attrs);
     }
 
     @TargetApi(21)
-    public ColorCollectionPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
+    public ColorValuesCollectionPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
     {
         super(context, attrs, defStyleAttr, defStyleRes);
         setParams(context, attrs);
@@ -116,7 +113,6 @@ public class ColorCollectionPreference extends Preference
     {
         previewKeys.clear();
         previewKeys.addAll(Arrays.asList(keys));
-        Log.d("DEBUG", "setPreviewKeys: " + keys[0]);
     }
 
     protected String colorTag = null;
@@ -192,10 +188,11 @@ public class ColorCollectionPreference extends Preference
                 if (activity != null)
                 {
                     Intent intent = new Intent(activity, ColorValuesSheetActivity.class);
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_TITLE, getTitle());
                     intent.putExtra(ColorValuesSheetActivity.EXTRA_APPWIDGET_ID, getAppWidgetID());
                     intent.putExtra(ColorValuesSheetActivity.EXTRA_COLORTAG, getColorTag());
                     intent.putExtra(ColorValuesSheetActivity.EXTRA_COLLECTION, getCollection());
-                    intent.putExtra(ColorValuesSheetActivity.EXTRA_TITLE, getTitle());
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_PREVIEW_KEYS, previewKeys.toArray(new String[0]));
                     intent.putExtra(ColorValuesSheetActivity.EXTRA_SHOW_ALPHA, showAlpha());
                     activity.startActivityForResult(intent, getRequestCode());
                     activity.overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollectionPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesCollectionPreference.java
@@ -143,11 +143,12 @@ public class ColorValuesCollectionPreference extends Preference
 
     protected void updateSummary(Context context)
     {
-        String selectedColorsID = getSelectedColorsID(context);
+        //String selectedColorsID = getSelectedColorsID(context);
+        String selectedColorsLabel = getSelectedColorsLabel(context);
         if (summaryStringResID != 0) {
-            setSummary(context.getString(summaryStringResID, (selectedColorsID != null ? selectedColorsID : context.getString(R.string.configLabel_tagDefault))));
+            setSummary(context.getString(summaryStringResID, (selectedColorsLabel != null ? selectedColorsLabel : context.getString(R.string.configLabel_tagDefault))));
         } else {
-            setSummary((selectedColorsID != null ? selectedColorsID : context.getString(R.string.configLabel_tagDefault)));
+            setSummary((selectedColorsLabel != null ? selectedColorsLabel : context.getString(R.string.configLabel_tagDefault)));
         }
     }
     protected int summaryStringResID = 0;
@@ -170,6 +171,9 @@ public class ColorValuesCollectionPreference extends Preference
 
     protected String getSelectedColorsID(Context context) {
         return (collection != null ? collection.getSelectedColorsID(context, getAppWidgetID(), getColorTag()) : null);
+    }
+    protected String getSelectedColorsLabel(Context context) {
+        return (collection != null ? collection.getSelectedColorsLabel(context, getAppWidgetID(), getColorTag()) : null);
     }
 
     public void initPreferenceOnClickListener(final Activity activity, int requestCode)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
@@ -154,7 +154,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
             onSaveColorValues();
         }
     };
-    protected void onSaveColorValues()
+    protected boolean onSaveColorValues()
     {
         if (validateInput())
         {
@@ -164,7 +164,9 @@ public class ColorValuesEditFragment extends ColorValuesFragment
             if (listener != null) {
                 listener.onSaveClicked(colorsID, colorValues);
             }
+            return true;
         }
+        return false;
     }
 
     private View.OnClickListener onCancelButtonClicked = new View.OnClickListener() {
@@ -443,15 +445,18 @@ public class ColorValuesEditFragment extends ColorValuesFragment
 
     protected void shareColors(Context context)
     {
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_TEXT, colorValues.toString());
-        startActivity(Intent.createChooser(intent, null));
+        if (colorValues != null)
+        {
+            Intent intent = new Intent(Intent.ACTION_SEND);
+            intent.setType("text/plain");
+            intent.putExtra(Intent.EXTRA_TEXT, colorValues.toString());
+            startActivity(Intent.createChooser(intent, null));
+        }
     }
 
     protected void deleteColors(Context context)
     {
-        if (listener != null && allowDelete()) {
+        if (listener != null && allowDelete() && colorValues != null) {
             listener.onDeleteClicked(colorValues.getID());
         }
     }
@@ -489,7 +494,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         }
     }
 
-    private PopupMenu.OnMenuItemClickListener onOverflowMenuItemSelected = new PopupMenu.OnMenuItemClickListener()
+    private final PopupMenu.OnMenuItemClickListener onOverflowMenuItemSelected = new PopupMenu.OnMenuItemClickListener()
     {
         @Override
         public boolean onMenuItemClick(MenuItem item)
@@ -519,9 +524,11 @@ public class ColorValuesEditFragment extends ColorValuesFragment
     @Override
     public boolean onOptionsItemSelected(MenuItem item)
     {
-        if (onOverflowMenuItemSelected.onMenuItemClick(item)) {
-            return true;
-        } else { return super.onOptionsItemSelected(item); }
+        //if (onOverflowMenuItemSelected.onMenuItemClick(item)) {
+        //    return true;
+        //} else {
+            return super.onOptionsItemSelected(item);
+        //}
     }
 
     protected void setBoolArg(String key, boolean value) {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
@@ -57,6 +57,7 @@ import com.forrestguice.suntimeswidget.settings.AppSettings;
 import com.forrestguice.suntimeswidget.settings.colors.ColorActivity;
 import com.forrestguice.suntimeswidget.settings.colors.ColorDialog;
 import com.forrestguice.suntimeswidget.settings.colors.ColorUtils;
+import com.forrestguice.suntimeswidget.settings.colors.pickers.ColorPickerFragment;
 import com.forrestguice.suntimeswidget.views.ViewUtils;
 
 import java.util.ArrayList;
@@ -541,6 +542,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         int[] colorOverUnder = getColorOverUnder(getActivity(), key);
         intent.putExtra(ColorDialog.KEY_COLOR_OVER, colorOverUnder[0]);
         intent.putExtra(ColorDialog.KEY_COLOR_UNDER, colorOverUnder[1]);
+        intent.putExtra(ColorDialog.KEY_PREVIEW_MODE, ColorPickerFragment.ColorPickerModel.PREVIEW_CONTRAST_RATIO);
 
         if (defaultValues != null) {
             intent.putExtra(ColorDialog.KEY_SUGGESTED, defaultValues.getColor(key));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
@@ -529,16 +529,20 @@ public class ColorValuesEditFragment extends ColorValuesFragment
 
     protected Intent pickColorIntent(String key, int requestCode)
     {
+        int color = colorValues.getColor(key);
+        ArrayList<Integer> recentColors = new ArrayList<>(new LinkedHashSet<>(colorValues.getColors()));
+        recentColors.add(0, color);
+
         Intent intent = new Intent(getActivity(), ColorActivity.class);
         intent.putExtra(ColorDialog.KEY_SHOWALPHA, showAlpha());
-        intent.setData(Uri.parse("color://" + String.format("#%08X", colorValues.getColor(key))));
-        intent.putExtra(ColorDialog.KEY_RECENT, new ArrayList<>(new LinkedHashSet<>(colorValues.getColors())));
+        intent.setData(Uri.parse("color://" + String.format("#%08X", color)));
+        intent.putExtra(ColorDialog.KEY_RECENT, recentColors);
         intent.putExtra(ColorDialog.KEY_LABEL, colorValues.getLabel(key));
 
         int[] colorOverUnder = getColorOverUnder(getActivity(), key);
         intent.putExtra(ColorDialog.KEY_COLOR_OVER, colorOverUnder[0]);
         intent.putExtra(ColorDialog.KEY_COLOR_UNDER, colorOverUnder[1]);
-        intent.putExtra(ColorDialog.KEY_PREVIEW_MODE, ColorPickerFragment.ColorPickerModel.PREVIEW_CONTRAST_RATIO);
+        intent.putExtra(ColorDialog.KEY_PREVIEW_MODE, ColorPickerFragment.ColorPickerModel.PREVIEW_LUMINANCE);
 
         if (defaultValues != null) {
             intent.putExtra(ColorDialog.KEY_SUGGESTED, defaultValues.getColor(key));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 /*
-    Copyright (C) 2020 Forrest Guice
+    Copyright (C) 2020-2024 Forrest Guice
     This file is part of SuntimesWidget.
 
     SuntimesWidget is free software: you can redistribute it and/or modify
@@ -63,6 +63,9 @@ public class ColorValuesEditFragment extends ColorValuesFragment
 {
     public static final String ARG_ALLOW_DELETE = "allowDelete";
     public static final boolean DEF_ALLOW_DELETE = true;
+
+    public static final String ARG_SHOW_ALPHA = "showAlpha";
+    public static final boolean DEF_SHOW_ALPHA = false;
 
     protected EditText editID;
     protected GridLayout panel;
@@ -382,7 +385,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         typedArray.recycle();
 
         Intent intent = new Intent(getActivity(), ColorActivity.class);
-        intent.putExtra(ColorDialog.KEY_SHOWALPHA, true);
+        intent.putExtra(ColorDialog.KEY_SHOWALPHA, showAlpha());
         intent.setData(Uri.parse("color://" + String.format("#%08X", colorValues.getColor(key))));
         intent.putExtra(ColorDialog.KEY_COLOR_UNDER, colorUnder);
         intent.putExtra(ColorDialog.KEY_COLOR_OVER, colorOver);
@@ -465,6 +468,13 @@ public class ColorValuesEditFragment extends ColorValuesFragment
     }
     public void setAllowDelete(boolean allowDelete) {
         setBoolArg(ARG_ALLOW_DELETE, allowDelete);
+    }
+
+    public boolean showAlpha() {
+        return getBoolArg(ARG_SHOW_ALPHA, DEF_SHOW_ALPHA);
+    }
+    public void setShowAlpha(boolean value) {
+        setBoolArg(ARG_SHOW_ALPHA, value);
     }
 
     public static final int REQUEST_IMPORT_THEME = 1000;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
@@ -268,7 +268,6 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         }
     }
 
-    //protected TextView[] colorEdits;
     protected void updateViews()
     {
         if (panel != null && colorValues != null)
@@ -287,6 +286,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
             }
 
             int[] defaultColors = getDefaultColors(context);
+            float textSizePx = getTextSizePx_medium(context);
 
             int c = 0;
             panel.removeAllViews();
@@ -343,12 +343,8 @@ public class ColorValuesEditFragment extends ColorValuesFragment
                 TextView colorEdit = new TextView(getActivity());
                 colorEdit.setText(colorLabel);
                 colorEdit.setOnClickListener(onColorEditClick(keys[i]));
-                colorEdit.setTextSize(TypedValue.COMPLEX_UNIT_PX, getTextSizePx_medium(context));
+                colorEdit.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizePx);
                 colorEdit.setGravity(Gravity.CENTER);
-
-                //LinearLayout.LayoutParams colorEdit_layoutParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-                //colorEdit_layoutParams.gravity = Gravity.CENTER;
-                //colorEdit.setLayoutParams(colorEdit_layoutParams);
 
                 if (itemBackground != null) {
                     colorEdit.setBackgroundResource(itemBackground.resourceId);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesEditFragment.java
@@ -73,7 +73,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
     public static final String ARG_SHOW_ALPHA = "showAlpha";
     public static final boolean DEF_SHOW_ALPHA = false;
 
-    protected EditText editID;
+    protected EditText editID, editLabel;
     protected GridLayout panel;
     protected ImageButton cancelButton;
 
@@ -112,7 +112,9 @@ public class ColorValuesEditFragment extends ColorValuesFragment
 
         panel = (GridLayout) content.findViewById(R.id.colorPanel);
         editID = (EditText) content.findViewById(R.id.editTextID);
+        editLabel = (EditText) content.findViewById(R.id.editTextLabel);
         setID(null);
+        setLabel(null);
 
         if (savedState != null) {
             onRestoreInstanceState(savedState);
@@ -142,6 +144,20 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         }
     }
 
+    /**
+     * @param colorsLabel value to set on edittext; use null to get the label from ColorValues
+     */
+    protected void setLabel(@Nullable String colorsLabel)
+    {
+        if (editLabel != null)
+        {
+            if (colorValues != null && colorsLabel == null) {
+                colorsLabel = colorValues.getLabel();
+            }
+            editLabel.setText(colorsLabel != null ? colorsLabel : "");
+        }
+    }
+
     protected boolean validateInput()
     {
         String colorsID = editID.getText().toString();
@@ -153,8 +169,15 @@ public class ColorValuesEditFragment extends ColorValuesFragment
             editID.setError(getString(R.string.error_colorid_spaces));
             editID.setSelection(colorsID.indexOf(" "), colorsID.indexOf(" ") + 1);
             return false;
+        }
 
-        } else return true;
+        String colorsLabel = editLabel.getText().toString();
+        if (colorsLabel.trim().isEmpty()) {
+            editLabel.setError(getString(R.string.error_colorlabel_empty));
+            return false;
+        }
+
+        return true;
     }
 
     private View.OnClickListener onSaveButtonClicked = new View.OnClickListener() {
@@ -168,7 +191,9 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         if (validateInput())
         {
             String colorsID = editID.getText().toString();
+            String colorsLabel = editLabel.getText().toString();
             colorValues.setID(colorsID);
+            colorValues.setLabel(colorsLabel);
 
             if (listener != null) {
                 listener.onSaveClicked(colorsID, colorValues);
@@ -214,6 +239,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
         out.putParcelable("defaultValues", defaultValues);
         out.putStringArray("filterValues", filterValues.toArray(new String[0]));
         out.putString("editID", editID.getText().toString());
+        out.putString("editLabel", editLabel.getText().toString());
         super.onSaveInstanceState(out);
     }
     protected void onRestoreInstanceState(@NonNull Bundle savedState)
@@ -225,6 +251,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
             filterValues  = new TreeSet<>(Arrays.asList(filter));
         }
         setID(savedState.getString("editID"));
+        setLabel(savedState.getString("editLabel"));
     }
 
     @Override
@@ -365,6 +392,7 @@ public class ColorValuesEditFragment extends ColorValuesFragment
     {
         colorValues = v;
         setID(null);
+        setLabel(null);
         updateViews();
     }
     public ColorValues getColorValues() {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
@@ -43,7 +43,6 @@ import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.views.ViewUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class ColorValuesSelectFragment extends ColorValuesFragment
@@ -485,25 +484,25 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
 
             items[0] = new ColorValuesItem(context.getString(R.string.configLabel_tagDefault), null, getPreviewColors(context, collection, null, previewKeys));
             for (int i=0; i<colorIDs.length; i++) {
-                items[i+1] = new ColorValuesItem(collection.getLabel(context, colorIDs[i]), colorIDs[i], getPreviewColors(context, collection, colorIDs[i], previewKeys));
+                items[i+1] = new ColorValuesItem(collection.getColorsLabel(context, colorIDs[i]), colorIDs[i], getPreviewColors(context, collection, colorIDs[i], previewKeys));
             }
             return items;
         }
 
         public static int[] getPreviewColors(Context context, @Nullable ColorValuesCollection<ColorValues> collection, @Nullable String colorsID, @Nullable String[] previewKeys)
         {
-            int[] colors = ((previewKeys != null) ? new int[previewKeys.length] : new int[0]);
-            if (collection != null && previewKeys != null && previewKeys.length > 0)
+            if (colorsID == null)
             {
-                ColorValues values = ((collection != null) ? collection.getColors(context, colorsID) : null);
-                if (values == null) {
-                    values = collection.getDefaultColors(context);
-                }
+                int[] colors = ((previewKeys != null) ? new int[previewKeys.length] : new int[0]);
+                ColorValues values = collection.getDefaultColors(context);
                 for (int i=0; i<previewKeys.length; i++) {
                     colors[i] = values.getColor(previewKeys[i]);
                 }
+                return colors;
+
+            } else {
+                return collection.getColors(context, colorsID, context.getColor(R.color.def_app_alarms_bright_color_end), previewKeys);
             }
-            return colors;
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
@@ -374,7 +374,7 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
             selectedColorsID = (colorCollection != null) ? colorCollection.getSelectedColorsID(getActivity(), getAppWidgetID(), getColorTag()) : null;
         }
 
-        boolean isDefault = (selectedColorsID == null);
+        boolean isDefault = ((colorCollection != null) ? colorCollection.isDefaultColorID(selectedColorsID) : (selectedColorsID == null));
 
         if (editButton != null) {
             editButton.setVisibility(isDefault ? View.GONE : View.VISIBLE);
@@ -494,9 +494,12 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
             if (colorsID == null)
             {
                 int[] colors = ((previewKeys != null) ? new int[previewKeys.length] : new int[0]);
-                ColorValues values = collection.getDefaultColors(context);
-                for (int i=0; i<previewKeys.length; i++) {
-                    colors[i] = values.getColor(previewKeys[i]);
+                if (previewKeys != null)
+                {
+                    ColorValues values = collection.getDefaultColors(context);
+                    for (int i=0; i<previewKeys.length; i++) {
+                        colors[i] = values.getColor(previewKeys[i]);
+                    }
                 }
                 return colors;
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
@@ -44,7 +44,7 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
 {
     public static final String ARG_APPWIDGETID = "appWidgetID";
     public static final int DEF_APPWIDGETID = 0;
-
+    
     public static final String ARG_ALLOW_EDIT = "allowEdit";
     public static final boolean DEF_ALLOW_EDIT = true;
 
@@ -224,6 +224,14 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
         }
     };
 
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        if (onOverflowMenuItemSelected.onMenuItemClick(item)) {
+            return true;
+        } else { return super.onOptionsItemSelected(item); }
+    }
+
     protected void showOverflowMenu(Context context, View v)
     {
         PopupMenu popup = new PopupMenu(context, v);
@@ -345,14 +353,22 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
 
     protected void updateControls()
     {
-        String selectedColorsID = (colorCollection != null) ? colorCollection.getSelectedColorsID(getActivity(), getAppWidgetID(), getColorTag()) : null;
+        //String selectedColorsID = (colorCollection != null) ? colorCollection.getSelectedColorsID(getActivity(), getAppWidgetID(), getColorTag()) : null;
+        String selectedColorsID;
+        if (selector != null) {
+            ColorValuesItem selectedColors = (ColorValuesItem) selector.getSelectedItem();
+            selectedColorsID = (selectedColors != null ? selectedColors.colorsID : null);
+        } else {
+            selectedColorsID = (colorCollection != null) ? colorCollection.getSelectedColorsID(getActivity(), getAppWidgetID(), getColorTag()) : null;
+        }
+
         boolean isDefault = (selectedColorsID == null);
 
         if (editButton != null) {
             editButton.setVisibility(isDefault ? View.GONE : View.VISIBLE);
         }
         if (addButton != null) {
-            addButton.setVisibility(isDefault ? View.VISIBLE : View.GONE);
+            addButton.setVisibility(isDefault || !getShowMenu() ? View.VISIBLE : View.GONE);
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
@@ -25,6 +25,7 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -504,7 +505,7 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
                 return colors;
 
             } else {
-                return collection.getColors(context, colorsID, context.getColor(R.color.def_app_alarms_bright_color_end), previewKeys);
+                return collection.getColors(context, colorsID, ContextCompat.getColor(context, R.color.def_app_alarms_bright_color_end), previewKeys);
             }
         }
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSelectFragment.java
@@ -485,7 +485,7 @@ public class ColorValuesSelectFragment extends ColorValuesFragment
 
             items[0] = new ColorValuesItem(context.getString(R.string.configLabel_tagDefault), null, getPreviewColors(context, collection, null, previewKeys));
             for (int i=0; i<colorIDs.length; i++) {
-                items[i+1] = new ColorValuesItem(colorIDs[i], colorIDs[i], getPreviewColors(context, collection, colorIDs[i], previewKeys));
+                items[i+1] = new ColorValuesItem(collection.getLabel(context, colorIDs[i]), colorIDs[i], getPreviewColors(context, collection, colorIDs[i], previewKeys));
             }
             return items;
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetActivity.java
@@ -1,0 +1,242 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/ 
+
+package com.forrestguice.suntimeswidget.colors;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+
+import com.forrestguice.suntimeswidget.R;
+import com.forrestguice.suntimeswidget.settings.AppSettings;
+import com.forrestguice.suntimeswidget.views.PopupMenuCompat;
+
+public class ColorValuesSheetActivity extends AppCompatActivity
+{
+    public static final String EXTRA_APPWIDGET_ID = "appWidgetID";
+    public static final String EXTRA_COLORTAG = "colorTag";
+    public static final String EXTRA_COLLECTION = "colorCollection";
+    public static final String EXTRA_SELECTED_COLORS_ID = "colorID";
+
+    public static final String EXTRA_TITLE = "activityTitle";
+    public static final String EXTRA_SUBTITLE = "activitySubtitle";
+
+    public static final String DIALOG_SHEET = "ColorSheet";
+    protected ColorValuesSheetFragment colorSheet;
+
+    public ColorValuesSheetActivity() {
+        super();
+    }
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(AppSettings.initLocale(newBase));
+    }
+
+    @Override
+    public void onCreate(Bundle icicle)
+    {
+        AppSettings.setTheme(this, AppSettings.loadThemePref(this));
+        super.onCreate(icicle);
+        setResult(RESULT_CANCELED);
+        setContentView(R.layout.layout_activity_colorsheet);
+
+        Intent intent = getIntent();
+        FragmentManager fragments = getSupportFragmentManager();
+
+        colorSheet = (ColorValuesSheetFragment) fragments.findFragmentByTag(DIALOG_SHEET);
+        if (colorSheet == null)
+        {
+            colorSheet = new ColorValuesSheetFragment();
+            colorSheet.setAppWidgetID(intent.getIntExtra(EXTRA_APPWIDGET_ID, 0));
+            colorSheet.setColorTag(intent.getStringExtra(EXTRA_COLORTAG));
+            colorSheet.setColorCollection((ColorValuesCollection) intent.getParcelableExtra(EXTRA_COLLECTION));
+            colorSheet.setMode(ColorValuesSheetFragment.MODE_SELECT);
+            colorSheet.setShowBack(false);
+            colorSheet.setShowMenu(false);
+            colorSheet.setHideAfterSave(false);
+            colorSheet.setPersistSelection(false);
+            colorSheet.setFragmentListener(sheetListener);
+        }
+
+        FragmentTransaction transaction = fragments.beginTransaction();
+        transaction.replace(R.id.fragmentContainer, colorSheet, DIALOG_SHEET);
+        transaction.commit();
+        fragments.executePendingTransactions();
+
+        Toolbar menuBar = (Toolbar) findViewById(R.id.app_menubar);
+        setSupportActionBar(menuBar);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null)
+        {
+            actionBar.setHomeButtonEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+
+            CharSequence title = intent.getCharSequenceExtra(EXTRA_TITLE);
+            if (title != null) {
+                actionBar.setTitle(title);
+            }
+            actionBar.setSubtitle(intent.getCharSequenceExtra(EXTRA_SUBTITLE));
+        }
+    }
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        if (colorSheet != null) {
+            colorSheet.updateViews();
+        }
+    }
+
+    private final ColorValuesSheetFragment.FragmentListener sheetListener = new ColorValuesSheetFragment.FragmentListener()
+    {
+        @Override
+        public void requestPeekHeight(int height) {
+            /* EMPTY */
+        }
+
+        @Override
+        public void requestHideSheet() {
+            onBackPressed();
+        }
+
+        @Override
+        public void requestExpandSheet() {
+            /* EMPTY */
+        }
+
+        @Override
+        public void onColorValuesSelected(@Nullable ColorValues values) {
+            /* EMPTY */
+        }
+
+        @Override
+        public void onModeChanged(int mode) {
+            invalidateOptionsMenu();
+        }
+
+        @Nullable
+        @Override
+        public ColorValues getDefaultValues() {
+            return ((colorSheet.colorCollection != null) ? colorSheet.colorCollection.getDefaultColors(ColorValuesSheetActivity.this) : null);
+        }
+    };
+
+    protected void selectColorID()
+    {
+        if (colorSheet.getMode() == ColorValuesSheetFragment.MODE_EDIT)
+        {
+            if (!colorSheet.editDialog.onSaveColorValues()) {
+                return;
+            }
+            ColorValues values = colorSheet.editDialog.getColorValues();
+            selectColorID((values != null) ? values.getID() : null);
+
+        } else {
+            selectColorID(colorSheet.listDialog.getSelectedID());
+        }
+    }
+
+    protected void selectColorID( String colorID )
+    {
+        Intent intent = createReturnIntent();
+        intent.putExtra(EXTRA_SELECTED_COLORS_ID, colorID);
+        setResult(Activity.RESULT_OK, intent);
+        finish();
+    }
+
+    @Override
+    public void onBackPressed()
+    {
+        setResult(Activity.RESULT_CANCELED, createReturnIntent());
+        finish();
+    }
+
+    protected Intent createReturnIntent()
+    {
+        Intent intent = new Intent();
+        intent.putExtra(EXTRA_APPWIDGET_ID, colorSheet.getAppWidgetID());
+        intent.putExtra(EXTRA_COLORTAG, colorSheet.getColorTag());
+        intent.putExtra(EXTRA_COLLECTION, colorSheet.colorCollection);
+        return intent;
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu)
+    {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu_colorsheet, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        switch (item.getItemId())
+        {
+            case R.id.action_colors_select:
+                selectColorID();
+                return true;
+
+            case R.id.action_colors_add:
+                colorSheet.listDialog.onAddItem();
+                return true;
+
+            case R.id.action_colors_delete:
+                colorSheet.listDialog.onDeleteItem();
+                return true;
+
+            case R.id.action_colors_share:
+                colorSheet.listDialog.onShareColors();
+                return true;
+
+            case R.id.action_colors_import:
+                colorSheet.listDialog.onImportColors();
+                return true;
+
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @SuppressWarnings("RestrictedApi")
+    @Override
+    protected boolean onPrepareOptionsPanel(View view, Menu menu)
+    {
+        PopupMenuCompat.forceActionBarIcons(menu);
+        return super.onPrepareOptionsPanel(view, menu);
+    }
+
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetActivity.java
@@ -36,6 +36,7 @@ import android.view.View;
 
 import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
+import com.forrestguice.suntimeswidget.settings.colors.ColorDialog;
 import com.forrestguice.suntimeswidget.views.PopupMenuCompat;
 
 public class ColorValuesSheetActivity extends AppCompatActivity
@@ -47,6 +48,7 @@ public class ColorValuesSheetActivity extends AppCompatActivity
 
     public static final String EXTRA_TITLE = "activityTitle";
     public static final String EXTRA_SUBTITLE = "activitySubtitle";
+    public static final String EXTRA_SHOW_ALPHA = ColorDialog.KEY_SHOWALPHA;
 
     public static final String DIALOG_SHEET = "ColorSheet";
     protected ColorValuesSheetFragment colorSheet;
@@ -83,6 +85,7 @@ public class ColorValuesSheetActivity extends AppCompatActivity
             colorSheet.setShowMenu(false);
             colorSheet.setHideAfterSave(false);
             colorSheet.setPersistSelection(false);
+            colorSheet.setShowAlpha(intent.getBooleanExtra(EXTRA_SHOW_ALPHA, false));
             colorSheet.setFragmentListener(sheetListener);
         }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetActivity.java
@@ -48,6 +48,8 @@ public class ColorValuesSheetActivity extends AppCompatActivity
 
     public static final String EXTRA_TITLE = "activityTitle";
     public static final String EXTRA_SUBTITLE = "activitySubtitle";
+    public static final String EXTRA_PREVIEW_KEYS = "previewKeys";
+
     public static final String EXTRA_SHOW_ALPHA = ColorDialog.KEY_SHOWALPHA;
 
     public static final String DIALOG_SHEET = "ColorSheet";
@@ -79,7 +81,8 @@ public class ColorValuesSheetActivity extends AppCompatActivity
             colorSheet = new ColorValuesSheetFragment();
             colorSheet.setAppWidgetID(intent.getIntExtra(EXTRA_APPWIDGET_ID, 0));
             colorSheet.setColorTag(intent.getStringExtra(EXTRA_COLORTAG));
-            colorSheet.setColorCollection((ColorValuesCollection) intent.getParcelableExtra(EXTRA_COLLECTION));
+            colorSheet.setColorCollection((ColorValuesCollection<ColorValues>) intent.getParcelableExtra(EXTRA_COLLECTION));
+            colorSheet.setPreviewKeys(intent.getStringArrayExtra(EXTRA_PREVIEW_KEYS));
             colorSheet.setMode(ColorValuesSheetFragment.MODE_SELECT);
             colorSheet.setShowBack(false);
             colorSheet.setShowMenu(false);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetDialog.java
@@ -78,6 +78,13 @@ public class ColorValuesSheetDialog extends BottomSheetDialogFragment
         return getArguments().getString("colorTag", null);
     }
 
+    public void setShowAlpha(boolean value) {
+        getArguments().putBoolean("showAlpha", value);
+    }
+    public boolean getShowAlpha() {
+        return getArguments().getBoolean("showAlpha", true);
+    }
+
     public void setApplyFilter(boolean value) {
         getArguments().putBoolean("applyFilter", value);
         if (colorSheet != null) {
@@ -224,6 +231,7 @@ public class ColorValuesSheetDialog extends BottomSheetDialogFragment
             colorSheet.setApplyFilter(applyFilter());
             colorSheet.setColorCollection(getColorCollection());
             colorSheet.setMode(ColorValuesSheetFragment.MODE_SELECT);
+            colorSheet.setShowAlpha(getShowAlpha());
             colorSheet.setFragmentListener(fragmentListener);
 
             FragmentTransaction transaction = fragments.beginTransaction();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetDialog.java
@@ -289,13 +289,21 @@ public class ColorValuesSheetDialog extends BottomSheetDialogFragment
         }
 
         @Override
-        public void requestHideSheet() {
+        public void requestHideSheet()
+        {
             dismiss();
+            if (dialogListener != null) {
+                requestHideSheet();
+            }
         }
 
         @Override
-        public void requestExpandSheet() {
+        public void requestExpandSheet()
+        {
             expandSheet(getDialog());
+            if (dialogListener != null) {
+                requestExpandSheet();
+            }
         }
 
         @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetDialog.java
@@ -289,21 +289,13 @@ public class ColorValuesSheetDialog extends BottomSheetDialogFragment
         }
 
         @Override
-        public void requestHideSheet()
-        {
+        public void requestHideSheet() {
             dismiss();
-            if (dialogListener != null) {
-                requestHideSheet();
-            }
         }
 
         @Override
-        public void requestExpandSheet()
-        {
+        public void requestExpandSheet() {
             expandSheet(getDialog());
-            if (dialogListener != null) {
-                requestExpandSheet();
-            }
         }
 
         @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
@@ -88,6 +88,7 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
             listDialog.setAppWidgetID(getAppWidgetID());
             listDialog.setColorTag(getColorTag());
             listDialog.setTheme(getThemeResID());
+            listDialog.setShowBack(getShowBack());
 
             FragmentTransaction transaction = fragments.beginTransaction();
             transaction.add(R.id.layout_color_sheet, listDialog, DIALOG_LIST);
@@ -415,6 +416,13 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
             toggleFragmentVisibility(getMode());
             onSelectColors(colorCollection.getSelectedColors(context, getAppWidgetID(), getColorTag()), "cancelEdit");
         }
+    }
+
+    public void setShowBack(boolean showBack) {
+        getArguments().putBoolean(ColorValuesSelectFragment.ARG_SHOW_BACK, showBack);
+    }
+    public boolean getShowBack() {
+        return getArguments().getBoolean(ColorValuesSelectFragment.ARG_SHOW_BACK, ColorValuesSelectFragment.DEF_SHOW_BACK);
     }
 
     public void setAppWidgetID(int id)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
@@ -40,6 +40,12 @@ import java.util.Locale;
 
 public class ColorValuesSheetFragment extends ColorValuesFragment
 {
+    public static final String ARG_HIDE_AFTER_SAVE = "hideAfterSave";    // sheet is hidden/dismissed after saving from edit dialog
+    public static final boolean DEF_HIDE_AFTER_SAVE = true;
+
+    public static final String ARG_PERSIST_SELECTION = "persistSelection";    // selection is automatically persisted from list dialog
+    public static final boolean DEF_PERSIST_SELECTION = true;
+
     public static final String DIALOG_LIST = "listDialog";
     public static final String DIALOG_EDIT = "editDialog";
     
@@ -89,6 +95,7 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
             listDialog.setColorTag(getColorTag());
             listDialog.setTheme(getThemeResID());
             listDialog.setShowBack(getShowBack());
+            listDialog.setShowMenu(getShowMenu());
 
             FragmentTransaction transaction = fragments.beginTransaction();
             transaction.add(R.id.layout_color_sheet, listDialog, DIALOG_LIST);
@@ -315,8 +322,11 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
         {
             //Log.d("DEBUG", "onItemSelected " + item.colorsID);
             Context context = getActivity();
-            if (context != null) {
-                colorCollection.setSelectedColorsID(context, item.colorsID, getAppWidgetID(), getColorTag());
+            if (context != null)
+            {
+                if (persistSelection()) {
+                    colorCollection.setSelectedColorsID(context, item.colorsID, getAppWidgetID(), getColorTag());
+                }
                 ColorValues selectedColors = colorCollection.getColors(context, item.colorsID);
                 onSelectColors(selectedColors, "onItemSelected");
             }
@@ -374,8 +384,11 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
 
                 setMode(MODE_SELECT);
                 toggleFragmentVisibility(getMode());
-                requestHideSheet();
                 Toast.makeText(context, getString(R.string.msg_colors_saved, colorsID), Toast.LENGTH_SHORT).show();
+
+                if (getHideAfterSave()) {
+                    requestHideSheet();
+                }
             }
         }
 
@@ -418,11 +431,32 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
         }
     }
 
+    public boolean persistSelection() {
+        return getArguments().getBoolean(ARG_PERSIST_SELECTION, DEF_PERSIST_SELECTION);
+    }
+    public void setPersistSelection(boolean value) {
+        getArguments().putBoolean(ARG_PERSIST_SELECTION, value);
+    }
+
+    public void setHideAfterSave(boolean showBack) {
+        getArguments().putBoolean(ARG_HIDE_AFTER_SAVE, showBack);
+    }
+    public boolean getHideAfterSave() {
+        return getArguments().getBoolean(ARG_HIDE_AFTER_SAVE, DEF_HIDE_AFTER_SAVE);
+    }
+
     public void setShowBack(boolean showBack) {
         getArguments().putBoolean(ColorValuesSelectFragment.ARG_SHOW_BACK, showBack);
     }
     public boolean getShowBack() {
         return getArguments().getBoolean(ColorValuesSelectFragment.ARG_SHOW_BACK, ColorValuesSelectFragment.DEF_SHOW_BACK);
+    }
+
+    public void setShowMenu(boolean showMenu) {
+        getArguments().putBoolean(ColorValuesSelectFragment.ARG_SHOW_MENU, showMenu);
+    }
+    public boolean getShowMenu() {
+        return getArguments().getBoolean(ColorValuesSelectFragment.ARG_SHOW_MENU, ColorValuesSelectFragment.DEF_SHOW_MENU);
     }
 
     public void setAppWidgetID(int id)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
@@ -97,6 +97,7 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
             listDialog.setTheme(getThemeResID());
             listDialog.setShowBack(getShowBack());
             listDialog.setShowMenu(getShowMenu());
+            listDialog.setPreviewKeys(previewKeys());
 
             FragmentTransaction transaction = fragments.beginTransaction();
             transaction.add(R.id.layout_color_sheet, listDialog, DIALOG_LIST);
@@ -199,6 +200,13 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
             }
         }
         updateViews();
+    }
+
+    public void setPreviewKeys(String... keys) {
+        getArguments().putStringArray("previewKeys", keys);
+    }
+    public String[] previewKeys() {
+        return getArguments().getStringArray("previewKeys");
     }
 
     protected String suggestColorValuesID(Context context)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
@@ -262,11 +262,13 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
             Context context = getActivity();
             if (context != null)
             {
+                String suggestedID = suggestColorValuesID(context);
                 ColorValues values = (colorsID == null)
                         ? colorCollection.getDefaultColors(context)
                         : colorCollection.getColors(context, colorsID);
                 editDialog.setColorValues(values);
-                editDialog.setID(suggestColorValuesID(context));
+                editDialog.setID(suggestedID);
+                editDialog.setLabel(suggestedID);
                 editDialog.setAllowDelete(false);
                 if (listener != null) {
                     editDialog.setDefaultValues(listener.getDefaultValues());
@@ -392,6 +394,7 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
                 colorCollection.setSelectedColorsID(context, colorsID, getAppWidgetID(), getColorTag());
                 onSelectColors(colorCollection.getColors(context, colorsID), "onSaveClicked");
 
+                listDialog.updateViews();
                 setMode(MODE_SELECT);
                 toggleFragmentVisibility(getMode());
                 Toast.makeText(context, getString(R.string.msg_colors_saved, colorsID), Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ColorValuesSheetFragment.java
@@ -34,6 +34,7 @@ import android.view.ViewGroup;
 
 import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
+import com.forrestguice.suntimeswidget.settings.colors.ColorDialog;
 import com.forrestguice.suntimeswidget.views.Toast;
 
 import java.util.Locale;
@@ -105,6 +106,7 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
         if (editDialog == null)
         {
             editDialog = new ColorValuesEditFragment();  // (ClockColorValuesEditFragment) fragments.findFragmentById(R.id.colorsFragment);
+            editDialog.setShowAlpha(getShowAlpha());
             editDialog.setTheme(getThemeResID());
             editDialog.setFilter(getFilter());
             editDialog.setApplyFilter(applyFilter());
@@ -457,6 +459,13 @@ public class ColorValuesSheetFragment extends ColorValuesFragment
     }
     public boolean getShowMenu() {
         return getArguments().getBoolean(ColorValuesSelectFragment.ARG_SHOW_MENU, ColorValuesSelectFragment.DEF_SHOW_MENU);
+    }
+
+    public void setShowAlpha(boolean showAlpha) {
+        getArguments().putBoolean(ColorValuesEditFragment.ARG_SHOW_ALPHA, showAlpha);
+    }
+    public boolean getShowAlpha() {
+        return getArguments().getBoolean(ColorValuesEditFragment.ARG_SHOW_ALPHA, ColorValuesEditFragment.DEF_SHOW_ALPHA);
     }
 
     public void setAppWidgetID(int id)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/colors/ResourceColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/colors/ResourceColorValues.java
@@ -36,6 +36,7 @@ public abstract class ResourceColorValues extends ColorValues
     public abstract String[] getColorKeys();
     public abstract int[] getColorAttrs();
     public abstract int[] getColorLabelsRes();
+    public abstract int[] getColorRoles();
     public abstract int[] getColorsResDark();
     public abstract int[] getColorsResLight();
     public abstract int[] getColorsFallback();
@@ -55,11 +56,17 @@ public abstract class ResourceColorValues extends ColorValues
         if (BuildConfig.DEBUG && (getColorKeys().length != getColorsFallback().length)) {
             throw new AssertionError("COLORS and COLORS_FALLBACK have different lengths! These arrays should be one-to-one.");
         }
+        if (BuildConfig.DEBUG && (getColorRoles().length != getColorKeys().length)) {
+            throw new AssertionError("COLOR_ROLES and COLOR_KEYS have different lengths! These arrays should be one-to-one.");
+        }
         String[] colorKeys = getColorKeys();
+        int[] colorRoles = getColorRoles();
         int[] fallbackColors = getColorsFallback();
-        for (int i=0; i<colorKeys.length; i++) {
+        for (int i=0; i<colorKeys.length; i++)
+        {
             setColor(colorKeys[i], fallbackColors[i]);
             setLabel(colorKeys[i], colorKeys[i]);
+            setRole(colorKeys[i], colorRoles[i]);
         }
     }
 
@@ -69,13 +76,18 @@ public abstract class ResourceColorValues extends ColorValues
         if (BuildConfig.DEBUG && (getColorKeys().length != getColorAttrs().length)) {
             throw new AssertionError("COLORS and COLORS_ATTR have different lengths! These arrays should be one-to-one." + getColorKeys().length + " != " + getColorAttrs().length);
         }
+        if (BuildConfig.DEBUG && (getColorRoles().length != getColorKeys().length)) {
+            throw new AssertionError("COLOR_ROLES and COLOR_KEYS have different lengths! These arrays should be one-to-one.");
+        }
         String[] colorKeys = getColorKeys();
+        int[] colorRoles = getColorRoles();
         int[] labelsResID = getColorLabelsRes();
         int[] defaultResID = darkTheme ? getColorsResDark() : getColorsResLight();
         TypedArray a = context.obtainStyledAttributes(getColorAttrs());
         for (int i=0; i<colorKeys.length; i++) {
             setColor(colorKeys[i], ContextCompat.getColor(context, a.getResourceId(i, defaultResID[i])));
             setLabel(colorKeys[i], (labelsResID[i] != 0) ? context.getString(labelsResID[i]) : colorKeys[i]);
+            setRole(colorKeys[i], colorRoles[i]);
         }
         a.recycle();
     }
@@ -94,13 +106,19 @@ public abstract class ResourceColorValues extends ColorValues
             }
         };
 
+        if (BuildConfig.DEBUG && (getColorRoles().length != getColorKeys().length)) {
+            throw new AssertionError("COLOR_ROLES and COLOR_KEYS have different lengths! These arrays should be one-to-one.");
+        }
+
         String[] colorKeys = getColorKeys();
+        int[] colorRoles = getColorRoles();
         int[] labelsResID = getColorLabelsRes();
         int[] defaultResID = darkTheme ? getColorsResDark() : getColorsResLight();
         for (int i=0; i<colorKeys.length; i++)
         {
             values.setColor(colorKeys[i], ContextCompat.getColor(context, defaultResID[i]));
             values.setLabel(colorKeys[i], (labelsResID[i] != 0) ? context.getString(labelsResID[i]) : colorKeys[i]);
+            values.setRole(colorKeys[i], colorRoles[i]);
         }
         values.setID(darkTheme ? context.getString(R.string.widgetThemes_dark) : context.getString(R.string.widgetThemes_light));
         return values;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/equinox/EquinoxColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/equinox/EquinoxColorValues.java
@@ -63,6 +63,14 @@ public class EquinoxColorValues extends ResourceColorValues
                 R.string.configLabel_themeColorWinter_text,
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_TEXT,
+                ROLE_TEXT,
+                ROLE_TEXT,
+                ROLE_TEXT
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.springColor_dark,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LightGraphColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LightGraphColorValues.java
@@ -106,6 +106,14 @@ public class LightGraphColorValues extends ResourceColorValues implements Parcel
             R.string.configLabel_themeColorGraphLabels, R.string.configLabel_themeColorGraphLabelsBG,
             R.string.configLabel_themeColorSpring, R.string.configLabel_themeColorSummer, R.string.configLabel_themeColorFall, R.string.configLabel_themeColorWinter
     };
+    public static final int[] COLOR_ROLES = new int[] {
+            ROLE_BACKGROUND, ROLE_BACKGROUND, ROLE_BACKGROUND, ROLE_BACKGROUND, ROLE_BACKGROUND,
+            ROLE_FOREGROUND, ROLE_FOREGROUND,
+            ROLE_FOREGROUND, ROLE_FOREGROUND,
+            ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND,
+            ROLE_TEXT, ROLE_BACKGROUND,
+            ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND
+    };
     protected static final int[] COLORS_FALLBACK = new int[]
     {
             Color.YELLOW, Color.CYAN, Color.BLUE, Color.DKGRAY, Color.BLACK,
@@ -128,6 +136,10 @@ public class LightGraphColorValues extends ResourceColorValues implements Parcel
     @Override
     public int[] getColorLabelsRes() {
         return LABELS_RESID;
+    }
+    @Override
+    public int[] getColorRoles() {
+        return COLOR_ROLES;
     }
     @Override
     public int[] getColorsResDark() {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LightMapColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LightMapColorValues.java
@@ -70,7 +70,14 @@ public class LightMapColorValues extends ResourceColorValues implements Parcelab
                 R.string.configLabel_themeColorGraphSunFill, R.string.configLabel_themeColorGraphSunStroke,
                 R.string.configLabel_themeColorGraphPointFill, R.string.configLabel_themeColorGraphPointStroke,
         };
-    };
+    }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_BACKGROUND, ROLE_BACKGROUND, ROLE_BACKGROUND, ROLE_BACKGROUND, ROLE_BACKGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND
+        };
+    }
     @Override
     public int[] getColorsResDark() {
         return new int[] {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LineGraphColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LineGraphColorValues.java
@@ -115,6 +115,7 @@ public class LineGraphColorValues extends ResourceColorValues implements Parcela
                 ROLE_TEXT, ROLE_BACKGROUND,
                 ROLE_BACKGROUND, ROLE_FOREGROUND,
                 ROLE_BACKGROUND, ROLE_FOREGROUND,
+                ROLE_BACKGROUND, ROLE_FOREGROUND,
                 ROLE_BACKGROUND, ROLE_FOREGROUND
         };
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LineGraphColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/graph/colors/LineGraphColorValues.java
@@ -105,6 +105,19 @@ public class LineGraphColorValues extends ResourceColorValues implements Parcela
                 R.string.configLabel_themeColorGraphMoonPathNightFill, R.string.configLabel_themeColorGraphMoonPathNightStroke,
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_BACKGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_TEXT, ROLE_BACKGROUND,
+                ROLE_BACKGROUND, ROLE_FOREGROUND,
+                ROLE_BACKGROUND, ROLE_FOREGROUND,
+                ROLE_BACKGROUND, ROLE_FOREGROUND
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.graphColor_night_dark,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/map/colors/WorldMapColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/map/colors/WorldMapColorValues.java
@@ -81,6 +81,14 @@ public class WorldMapColorValues extends ResourceColorValues
                 R.string.configLabel_themeColorGraphAxis, R.string.configLabel_themeColorGraphGridMajor, R.string.configLabel_themeColorGraphGridMinor,
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_BACKGROUND, ROLE_BACKGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.map_background_dark, R.color.map_foreground_dark,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/map/colors/WorldMapColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/map/colors/WorldMapColorValues.java
@@ -84,7 +84,8 @@ public class WorldMapColorValues extends ResourceColorValues
     public int[] getColorRoles() {
         return new int[] {
                 ROLE_BACKGROUND, ROLE_BACKGROUND,
-                ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_BACKGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_BACKGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND,
                 ROLE_FOREGROUND, ROLE_FOREGROUND,
                 ROLE_FOREGROUND, ROLE_FOREGROUND, ROLE_FOREGROUND
         };

--- a/app/src/main/java/com/forrestguice/suntimeswidget/moon/colors/MoonApsisColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/moon/colors/MoonApsisColorValues.java
@@ -53,6 +53,11 @@ public class MoonApsisColorValues extends ResourceColorValues implements Parcela
                 R.string.configLabel_themeColorMoonApogeeText, R.string.configLabel_themeColorMoonPerigeeText
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_TEXT, ROLE_TEXT
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.table_moon_rising_dark, R.color.table_moon_setting_dark,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/moon/colors/MoonPhasesColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/moon/colors/MoonPhasesColorValues.java
@@ -58,6 +58,12 @@ public class MoonPhasesColorValues extends ResourceColorValues implements Parcel
                 R.string.configLabel_themeColorMoonFull, R.string.configLabel_themeColorMoonWaning,
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_FOREGROUND, ROLE_FOREGROUND,
+                ROLE_FOREGROUND, ROLE_FOREGROUND
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.moonIcon_color_new_dark, R.color.moonIcon_color_waxing,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/moon/colors/MoonRiseSetColorValues.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/moon/colors/MoonRiseSetColorValues.java
@@ -59,6 +59,12 @@ public class MoonRiseSetColorValues extends ResourceColorValues implements Parce
                 R.string.configLabel_themeColorMoonset, R.string.configLabel_themeColorMoonset_text,
         };
     }
+    public int[] getColorRoles() {
+        return new int[] {
+                ROLE_FOREGROUND, ROLE_TEXT,
+                ROLE_FOREGROUND, ROLE_TEXT
+        };
+    }
     public int[] getColorsResDark() {
         return new int[] {
                 R.color.moonIcon_color_rising_dark, R.color.table_moon_rising_dark,

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/ActionButtonPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/ActionButtonPreference.java
@@ -20,6 +20,7 @@ package com.forrestguice.suntimeswidget.settings;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
@@ -27,28 +28,50 @@ import android.widget.ImageView;
 
 import com.forrestguice.suntimeswidget.R;
 
+/**
+ * A preference with an "action" button; should be provided with a `widgetLayout` containing
+ * ImageButton with id `actionButton0`.
+ */
 public class ActionButtonPreference extends ListPreference
 {
-    public ActionButtonPreference(Context context)
-    {
+    public ActionButtonPreference(Context context) {
         super(context);
     }
 
     public ActionButtonPreference(Context context, AttributeSet attrs)
     {
         super(context, attrs);
+        setParams(context, attrs);
     }
 
     @TargetApi(21)
     public ActionButtonPreference(Context context, AttributeSet attrs, int defStyleAttr)
     {
         super(context, attrs, defStyleAttr);
+        setParams(context, attrs);
     }
 
     @TargetApi(21)
     public ActionButtonPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
     {
         super(context, attrs, defStyleAttr, defStyleRes);
+        setParams(context, attrs);
+    }
+
+    public void setParams(Context context, AttributeSet attrs)
+    {
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ColorListPreference, 0, 0);
+        try {
+            actionButtonContentDescription = a.getString(R.styleable.ActionButtonPreference_actionButtonContentDescription);
+
+        } finally {
+            a.recycle();
+        }
+    }
+
+    private String actionButtonContentDescription = null;
+    public String getActionButtonContentDescription() {
+        return actionButtonContentDescription;
     }
 
     @Override
@@ -61,6 +84,7 @@ public class ActionButtonPreference extends ListPreference
         {
             boolean enabled = isEnabled();
             actionButton.setEnabled(enabled);
+            actionButton.setContentDescription(actionButtonContentDescription);
 
             if (Build.VERSION.SDK_INT >= 11) {
                 actionButton.setAlpha(enabled ? 1f : 0f);
@@ -70,7 +94,7 @@ public class ActionButtonPreference extends ListPreference
         }
     }
 
-    private View.OnClickListener onActionClicked = new View.OnClickListener() {
+    private final View.OnClickListener onActionClicked = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
             if (actionButtonPreferenceListener != null) {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/IntegerPickerPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/IntegerPickerPreference.java
@@ -145,6 +145,7 @@ public class IntegerPickerPreference extends DialogPreference
         pickerLabel.setText(createSummaryString(value));
     }
 
+    @Override
     protected void onPrepareDialogBuilder(AlertDialog.Builder builder)
     {
         super.onPrepareDialogBuilder(builder);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/SettingsActivityInterface.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/SettingsActivityInterface.java
@@ -38,6 +38,7 @@ public interface SettingsActivityInterface
     int REQUEST_TAPACTION_NOTE = 70;
     int REQUEST_MANAGE_EVENTS = 80;
     int REQUEST_WELCOME_SCREEN = 90;
+    int REQUEST_PICKCOLORS_BRIGHTALARM = 100;
 
     String RECREATE_ACTIVITY = "recreate_activity";
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/SuntimesBackupRestoreTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/SuntimesBackupRestoreTask.java
@@ -35,6 +35,8 @@ import com.forrestguice.suntimeswidget.SuntimesUtils;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmDatabaseAdapter;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmSettings;
 import com.forrestguice.suntimeswidget.alarmclock.bedtime.BedtimeSettings;
+import com.forrestguice.suntimeswidget.alarmclock.ui.colors.AlarmColorValues;
+import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValuesCollection;
 import com.forrestguice.suntimeswidget.colors.AppColorValues;
 import com.forrestguice.suntimeswidget.colors.AppColorValuesCollection;
 import com.forrestguice.suntimeswidget.colors.ColorValues;
@@ -231,6 +233,7 @@ public class SuntimesBackupRestoreTask extends AsyncTask<Void, Void, SuntimesBac
         if (keys.contains(SuntimesBackupTask.KEY_COLORS)) {
             c += importAppColors(context, SuntimesBackupTask.KEY_COLORS_APPCOLORS, 0, report, allValues.get(SuntimesBackupTask.KEY_COLORS_APPCOLORS));
             c += importMapColors(context, SuntimesBackupTask.KEY_COLORS_MAPCOLORS, 0, report, allValues.get(SuntimesBackupTask.KEY_COLORS_MAPCOLORS));
+            c += importAlarmColors(context, SuntimesBackupTask.KEY_COLORS_ALARMCOLORS, 0, report, allValues.get(SuntimesBackupTask.KEY_COLORS_ALARMCOLORS));
         }
 
         if (keys.contains(SuntimesBackupTask.KEY_ALARMITEMS))
@@ -264,6 +267,7 @@ public class SuntimesBackupRestoreTask extends AsyncTask<Void, Void, SuntimesBac
         prefTypes.putAll(BedtimeSettings.getPrefTypes());
         prefTypes.putAll(AppColorValuesCollection.getPrefTypes());
         prefTypes.putAll(WorldMapColorValuesCollection.getPrefTypes());
+        prefTypes.putAll(BrightAlarmColorValuesCollection.getPrefTypes());
 
         if (contentValues != null)
         {
@@ -294,7 +298,7 @@ public class SuntimesBackupRestoreTask extends AsyncTask<Void, Void, SuntimesBac
             }
             @Override
             public ColorValuesCollection<ColorValues> createColorValuesCollection(Context context) {
-                return new AppColorValuesCollection<ColorValues>();
+                return new AppColorValuesCollection<ColorValues>(context);
             }
         }, report, contentValues);
     }
@@ -308,7 +312,21 @@ public class SuntimesBackupRestoreTask extends AsyncTask<Void, Void, SuntimesBac
             }
             @Override
             public ColorValuesCollection<ColorValues> createColorValuesCollection(Context context) {
-                return new WorldMapColorValuesCollection<ColorValues>();
+                return new WorldMapColorValuesCollection<ColorValues>(context);
+            }
+        }, report, contentValues);
+    }
+    protected static int importAlarmColors(Context context, String key, int method, StringBuilder report, @Nullable ContentValues... contentValues)
+    {
+        return importColors(context, key, method, new ColorValuesImporter()
+        {
+            @Override
+            public ColorValues createColorValues(Context context) {
+                return new AlarmColorValues(context, true);
+            }
+            @Override
+            public ColorValuesCollection<ColorValues> createColorValuesCollection(Context context) {
+                return new BrightAlarmColorValuesCollection<ColorValues>(context);
             }
         }, report, contentValues);
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/SuntimesBackupTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/SuntimesBackupTask.java
@@ -45,6 +45,7 @@ import com.forrestguice.suntimeswidget.alarmclock.AlarmClockItem;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmClockItemExportTask;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmDatabaseAdapter;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmEventProvider;
+import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValuesCollection;
 import com.forrestguice.suntimeswidget.colors.AppColorValuesCollection;
 import com.forrestguice.suntimeswidget.colors.ColorValues;
 import com.forrestguice.suntimeswidget.colors.ColorValuesCollection;
@@ -91,6 +92,7 @@ public class SuntimesBackupTask extends WidgetSettingsExportTask
     public static final String KEY_COLORS = "Colors";
     public static final String KEY_COLORS_APPCOLORS = KEY_COLORS + "_" + "AppColors";
     public static final String KEY_COLORS_MAPCOLORS = KEY_COLORS + "_" + "MapColors";
+    public static final String KEY_COLORS_ALARMCOLORS = KEY_COLORS + "_" + "AlarmColors";
 
     public static final String[] ALL_KEYS = new String[] {
             KEY_APPSETTINGS, KEY_COLORS, KEY_WIDGETSETTINGS, KEY_ALARMITEMS, KEY_EVENTITEMS, KEY_PLACEITEMS, KEY_ACTIONS, KEY_WIDGETTHEMES
@@ -245,7 +247,14 @@ public class SuntimesBackupTask extends WidgetSettingsExportTask
                 out.write(",\n".getBytes());
             }
             out.write(("\"" + KEY_COLORS_MAPCOLORS + "\": ").getBytes());    // include Map Colors
-            writeColorsJSONArray(context, new WorldMapColorValuesCollection<ColorValues>(), out);
+            writeColorsJSONArray(context, new WorldMapColorValuesCollection<ColorValues>(context), out);
+            c++;
+
+            if (c > 0) {
+                out.write(",\n".getBytes());
+            }
+            out.write(("\"" + KEY_COLORS_ALARMCOLORS + "\": ").getBytes());    // include Alarm Colors
+            writeColorsJSONArray(context, new BrightAlarmColorValuesCollection<ColorValues>(context), out);
             c++;
         }
 
@@ -461,6 +470,9 @@ public class SuntimesBackupTask extends WidgetSettingsExportTask
         }
         if (SuntimesBackupTask.KEY_COLORS_MAPCOLORS.equals(key)) {
             return SuntimesUtils.fromHtml(context.getString(R.string.restorebackup_dialog_item_colors_mapcolors));
+        }
+        if (SuntimesBackupTask.KEY_COLORS_ALARMCOLORS.equals(key)) {
+            return SuntimesUtils.fromHtml(context.getString(R.string.restorebackup_dialog_item_colors_alarmcolors));
         }
         if (SuntimesBackupTask.KEY_WIDGETSETTINGS.equals(key)) {
             return SuntimesUtils.fromHtml(context.getString(R.string.restorebackup_dialog_item_widgetsettings));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorActivity.java
@@ -114,6 +114,7 @@ public class ColorActivity extends AppCompatActivity
         colorDialog.setRecentColors(intent.getIntegerArrayListExtra(ColorDialog.KEY_RECENT));
         colorDialog.setShowAlpha(intent.getBooleanExtra(ColorDialog.KEY_SHOWALPHA, false));
         colorDialog.setSuggestedColor(intent.getIntExtra(ColorDialog.KEY_SUGGESTED, Integer.MIN_VALUE));
+        colorDialog.setColorLabel(intent.getStringExtra(ColorDialog.KEY_LABEL));
 
         int color = Color.WHITE;
         Uri data = intent.getData();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorActivity.java
@@ -30,6 +30,7 @@ import android.view.View;
 
 import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
+import com.forrestguice.suntimeswidget.settings.colors.pickers.ColorPickerFragment;
 
 /**
  * This activity can be used to pick a color:
@@ -141,6 +142,10 @@ public class ColorActivity extends AppCompatActivity
         if (intent.hasExtra(ColorDialog.KEY_COLOR_OVER)) {
             colorDialog.getArguments().putInt(ColorDialog.KEY_COLOR_OVER,
                     intent.getIntExtra(ColorDialog.KEY_COLOR_OVER, color));
+        }
+        if (intent.hasExtra(ColorDialog.KEY_PREVIEW_MODE)) {
+            colorDialog.getArguments().putInt(ColorDialog.KEY_PREVIEW_MODE,
+                    intent.getIntExtra(ColorDialog.KEY_PREVIEW_MODE, ColorPickerFragment.ColorPickerModel.PREVIEW_TEXT));
         }
 
         colorDialog.setColor(color);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorCollectionPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorCollectionPreference.java
@@ -1,0 +1,208 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.settings.colors;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.TypedArray;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+
+import com.forrestguice.suntimeswidget.R;
+import com.forrestguice.suntimeswidget.colors.ColorValues;
+import com.forrestguice.suntimeswidget.colors.ColorValuesCollection;
+import com.forrestguice.suntimeswidget.colors.ColorValuesSheetActivity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ColorCollectionPreference extends Preference
+{
+    public ColorCollectionPreference(Context context) {
+        super(context);
+    }
+
+    public ColorCollectionPreference(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+        setParams(context, attrs);
+    }
+
+    @TargetApi(21)
+    public ColorCollectionPreference(Context context, AttributeSet attrs, int defStyleAttr)
+    {
+        super(context, attrs, defStyleAttr);
+        setParams(context, attrs);
+    }
+
+    @TargetApi(21)
+    public ColorCollectionPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
+    {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        setParams(context, attrs);
+    }
+
+    public void setParams(Context context, AttributeSet attrs)
+    {
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ColorCollectionPreference, 0, 0);
+        try {
+            colorTag = a.getString(R.styleable.ColorCollectionPreference_colorTag);
+            appWidgetID = a.getInt(R.styleable.ColorCollectionPreference_appWidgetID, appWidgetID);
+            showAlpha = a.getBoolean(R.styleable.ColorCollectionPreference_showAlpha, showAlpha);
+            summaryStringResID = a.getResourceId(R.styleable.ColorCollectionPreference_android_summary, 0);
+
+            int previewArrayID = a.getResourceId(R.styleable.ColorCollectionPreference_previewKeys, 0);
+            if (previewArrayID != 0) {
+                setPreviewKeys(context.getResources().getStringArray(previewArrayID));
+            }
+
+        } finally {
+            a.recycle();
+        }
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        if (collection != null && !previewKeys.isEmpty())
+        {
+            int[] previewViewIDs = new int[] { R.id.colorPreview0, R.id.colorPreview1, R.id.colorPreview2 };
+
+            ColorValues values = collection.getSelectedColors(getContext(), getAppWidgetID(), getColorTag());
+            if (values == null) {
+                values = collection.getDefaultColors(getContext());
+            }
+
+            for (int i=0; i<previewViewIDs.length; i++)
+            {
+                View colorPreview = view.findViewById(previewViewIDs[i]);
+                if (colorPreview != null)
+                {
+                    if (i < previewKeys.size()) {
+                        colorPreview.setBackgroundColor(values.getColor(previewKeys.get(i)));
+                        colorPreview.setVisibility(View.VISIBLE);
+                    } else {
+                        colorPreview.setVisibility(View.GONE);
+                    }
+                }
+            }
+        }
+    }
+
+    protected ArrayList<String> previewKeys = new ArrayList<>();
+    public void setPreviewKeys(String... keys)
+    {
+        previewKeys.clear();
+        previewKeys.addAll(Arrays.asList(keys));
+        Log.d("DEBUG", "setPreviewKeys: " + keys[0]);
+    }
+
+    protected String colorTag = null;
+    public String getColorTag() {
+        return colorTag;
+    }
+    public void setColorTag(String value) {
+        colorTag = value;
+    }
+
+    protected int appWidgetID = 0;
+    public int getAppWidgetID() {
+        return appWidgetID;
+    }
+    public void setAppWidgetID(int value) {
+        appWidgetID = value;
+    }
+
+    protected ColorValuesCollection<ColorValues> collection = null;
+    public ColorValuesCollection<ColorValues> getCollection() {
+        return collection;
+    }
+    public void setCollection(Context context, ColorValuesCollection<ColorValues> value)
+    {
+        collection = value;
+        updateSummary(context);
+    }
+
+    protected void updateSummary(Context context)
+    {
+        String selectedColorsID = getSelectedColorsID(context);
+        if (summaryStringResID != 0) {
+            setSummary(context.getString(summaryStringResID, (selectedColorsID != null ? selectedColorsID : context.getString(R.string.configLabel_tagDefault))));
+        } else {
+            setSummary((selectedColorsID != null ? selectedColorsID : context.getString(R.string.configLabel_tagDefault)));
+        }
+    }
+    protected int summaryStringResID = 0;
+
+    protected boolean showAlpha = false;
+    public boolean showAlpha() {
+        return showAlpha;
+    }
+    public void setShowAlpha(boolean value) {
+        showAlpha = value;
+    }
+
+    protected int requestCode = 0;
+    public int getRequestCode() {
+        return requestCode;
+    }
+    public void setRequestCode(int value) {
+        requestCode = value;
+    }
+
+    protected String getSelectedColorsID(Context context) {
+        return (collection != null ? collection.getSelectedColorsID(context, getAppWidgetID(), getColorTag()) : null);
+    }
+
+    public void initPreferenceOnClickListener(final Activity activity, int requestCode)
+    {
+        setRequestCode(requestCode);
+        setOnPreferenceClickListener(createPreferenceOnClickListener(activity));
+    }
+
+    protected Preference.OnPreferenceClickListener createPreferenceOnClickListener(final Activity activity)
+    {
+        return new Preference.OnPreferenceClickListener()
+        {
+            @Override
+            public boolean onPreferenceClick(Preference preference)
+            {
+                if (activity != null)
+                {
+                    Intent intent = new Intent(activity, ColorValuesSheetActivity.class);
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_APPWIDGET_ID, getAppWidgetID());
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_COLORTAG, getColorTag());
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_COLLECTION, getCollection());
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_TITLE, getTitle());
+                    intent.putExtra(ColorValuesSheetActivity.EXTRA_SHOW_ALPHA, showAlpha());
+                    activity.startActivityForResult(intent, getRequestCode());
+                    activity.overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);
+                }
+                return false;
+            }
+        };
+    }
+
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorDialog.java
@@ -63,6 +63,7 @@ public class ColorDialog extends BottomSheetDialogFragment
     public static final String KEY_COLOR = "color";
     public static final String KEY_COLOR_UNDER = "color_under";
     public static final String KEY_COLOR_OVER = "color_over";
+    public static final String KEY_PREVIEW_MODE = "previewMode";
     public static final String KEY_RECENT = "recentColors";
     public static final String KEY_SUGGESTED = "suggestedColor";
     public static final String KEY_LABEL = "color_label";
@@ -146,6 +147,7 @@ public class ColorDialog extends BottomSheetDialogFragment
         viewModel.setColor(getArguments().getInt(KEY_COLOR));
         viewModel.setColorUnder(getArguments().getInt(KEY_COLOR_UNDER));
         viewModel.setColorOver(getArguments().getInt(KEY_COLOR_OVER));
+        viewModel.setPreviewMode(getArguments().getInt(KEY_PREVIEW_MODE));
         viewModel.setShowAlpha(showAlpha());
 
         if (savedState != null)

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorDialog.java
@@ -116,8 +116,12 @@ public class ColorDialog extends BottomSheetDialogFragment
     public boolean showAlpha() {
         return colorPagerArgs.getBoolean(KEY_SHOWALPHA, false);
     }
-    public void setShowAlpha(boolean value) {
+    public void setShowAlpha(boolean value)
+    {
         colorPagerArgs.putBoolean(KEY_SHOWALPHA, value);
+        if (viewModel != null) {
+            viewModel.setShowAlpha(value);
+        }
         filterRecentColors();
     }
 
@@ -132,6 +136,7 @@ public class ColorDialog extends BottomSheetDialogFragment
         viewModel.setColor(getArguments().getInt(KEY_COLOR));
         viewModel.setColorUnder(getArguments().getInt(KEY_COLOR_UNDER));
         viewModel.setColorOver(getArguments().getInt(KEY_COLOR_OVER));
+        viewModel.setShowAlpha(showAlpha());
 
         if (savedState != null)
         {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorDialog.java
@@ -46,6 +46,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
@@ -64,6 +65,7 @@ public class ColorDialog extends BottomSheetDialogFragment
     public static final String KEY_COLOR_OVER = "color_over";
     public static final String KEY_RECENT = "recentColors";
     public static final String KEY_SUGGESTED = "suggestedColor";
+    public static final String KEY_LABEL = "color_label";
 
     public ColorDialog() {
         setArguments(colorPagerArgs);
@@ -111,6 +113,14 @@ public class ColorDialog extends BottomSheetDialogFragment
         if (isAdded()) {
             updateViews(getActivity());
         }
+    }
+
+    @Nullable
+    public String getColorLabel() {
+        return colorPagerArgs.getString(KEY_LABEL, null);
+    }
+    public void setColorLabel(String value) {
+        colorPagerArgs.putString(KEY_LABEL, value);
     }
 
     public boolean showAlpha() {
@@ -215,6 +225,18 @@ public class ColorDialog extends BottomSheetDialogFragment
 
     private void initViews(Context context, View dialogContent)
     {
+        TextView subtitle = (TextView) dialogContent.findViewById(R.id.dialog_subtitle);
+        if (subtitle != null)
+        {
+            String colorLabel = getColorLabel();
+            if (colorLabel != null) {
+                subtitle.setText(colorLabel);
+                subtitle.setVisibility(View.VISIBLE);
+            } else {
+                subtitle.setVisibility(View.GONE);
+            }
+        }
+
         TabLayout colorPagerTabs = (TabLayout) dialogContent.findViewById(R.id.color_pager_tabs);
         colorPager = (ViewPager) dialogContent.findViewById(R.id.color_pager);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorListPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorListPreference.java
@@ -1,0 +1,247 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.settings.colors;
+
+import android.annotation.TargetApi;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.os.Build;
+import android.preference.DialogPreference;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.forrestguice.suntimeswidget.R;
+
+import java.util.ArrayList;
+
+/**
+ * A dialog preference that allows choosing from a list of pre-defined colors.
+ */
+@TargetApi(11)
+public class ColorListPreference extends DialogPreference
+{
+    private final int FALLBACK_DEFAULT_VALUE = Color.WHITE;
+
+    private int value;
+    private final ArrayList<Integer> colors = new ArrayList<>();
+
+    private TextView label;
+    private LinearLayout preview;
+    private RecyclerView picker;
+    private ColorsAdapter adapter;
+
+    @TargetApi(21)
+    public ColorListPreference(Context context) {
+        super(context);
+    }
+
+    public ColorListPreference(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+        setParams(context, attrs);
+    }
+
+    @TargetApi(21)
+    public ColorListPreference(Context context, AttributeSet attrs, int defStyleAttr)
+    {
+        super(context, attrs, defStyleAttr);
+        setParams(context, attrs);
+    }
+
+    @TargetApi(21)
+    public ColorListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
+    {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        setParams(context, attrs);
+    }
+
+    public void setParams(Context context, AttributeSet attrs)
+    {
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ColorListPreference, 0, 0);
+        try {
+            int arrayID = a.getResourceId(R.styleable.ColorListPreference_colorValues, 0);
+            if (arrayID != 0)
+            {
+                int[] array = context.getResources().getIntArray(arrayID);
+                if (array != null)
+                {
+                    colors.clear();
+                    for (int i=0; i<array.length; i++) {
+                        colors.add(array[i]);
+                    }
+                }
+            }
+
+        } finally {
+            a.recycle();
+        }
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        View colorView = view.findViewById(R.id.colorPreview);
+        if (colorView != null) {
+            colorView.setBackgroundColor(getValue());
+        }
+    }
+
+    @Override
+    protected View onCreateDialogView()
+    {
+        Context context = getContext();
+
+        float marginTopBottom = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8, getContext().getResources().getDisplayMetrics());
+        float marginLeftRight;
+        TypedArray a = context.obtainStyledAttributes(new int[] { R.attr.dialogPreferredPadding });
+        marginLeftRight = context.getResources().getDimension(a.getResourceId(0, R.dimen.settingsGroup_margin));
+        a.recycle();
+
+        // label
+        label = new TextView(getContext());
+        LinearLayout.LayoutParams label_layoutParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        label_layoutParams.gravity = Gravity.START | Gravity.CENTER_VERTICAL;
+        label_layoutParams.setMargins((int)marginLeftRight, (int)marginTopBottom, (int)marginLeftRight, (int)marginTopBottom);
+        label.setVisibility(View.INVISIBLE);
+        label.setLayoutParams(label_layoutParams);
+
+        // preview
+        preview = new LinearLayout(getContext());
+        LinearLayout.LayoutParams preview_layoutParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        preview_layoutParams.gravity = Gravity.START | Gravity.CENTER_VERTICAL;
+        preview_layoutParams.setMargins((int)marginLeftRight, (int)marginTopBottom, (int)marginLeftRight, (int)marginTopBottom);
+        preview.setLayoutParams(preview_layoutParams);
+        preview.addView(label);
+
+        // color picker
+        adapter = new ColorsAdapter(colors);
+        adapter.setSelectedColor(getValue());
+        adapter.setItemLayoutResID(R.layout.layout_listitem_color2);
+        adapter.setOnColorButtonClickListener(new ColorChangeListener()
+        {
+            @Override
+            public void onColorChanged(int color) {
+                updatePreview(color);
+            }
+        });
+
+        picker = new RecyclerView(getContext());
+        picker.setHasFixedSize(true);
+        picker.setLayoutManager(new GridLayoutManager(getContext(), getNumColumns(), GridLayoutManager.VERTICAL, false));
+
+        LinearLayout.LayoutParams picker_layoutParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        picker_layoutParams.gravity = Gravity.CENTER;
+        picker.setLayoutParams(picker_layoutParams);
+
+        // dialog layout
+        LinearLayout dialogView = new LinearLayout(getContext());
+        dialogView.setOrientation(LinearLayout.VERTICAL);
+
+        LinearLayout.LayoutParams dialog_layoutParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        dialog_layoutParams.gravity = Gravity.CENTER;
+        dialogView.setLayoutParams(dialog_layoutParams);
+
+        dialogView.addView(preview);
+        dialogView.addView(picker);
+        return dialogView;
+    }
+
+    @Override
+    protected void onBindDialogView(View v)
+    {
+        super.onBindDialogView(v);
+        updatePreview(getValue());
+        adapter.setSelectedColor(getValue());
+        picker.setAdapter(adapter);
+        picker.scrollToPosition(0);
+    }
+
+    protected void updatePreview(int color)
+    {
+        label.setText(createSummaryString(color));
+        preview.setBackgroundColor(color);
+        preview.setContentDescription(createSummaryString(color));
+    }
+
+    @Override
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        super.onPrepareDialogBuilder(builder);
+    }
+
+    @Override
+    protected void onDialogClosed(boolean result)
+    {
+        if (result)
+        {
+            Integer changedValue = adapter.getSelectedColor();
+            if (changedValue != null && callChangeListener(changedValue)) {
+                setValue(changedValue);
+            }
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int i) {
+        return a.getInt(i, FALLBACK_DEFAULT_VALUE);
+    }
+
+    @Override
+    protected void onSetInitialValue(boolean restoreValue, Object defaultValue0)
+    {
+        super.onSetInitialValue(restoreValue, defaultValue0);
+        int defValue = ((defaultValue0 != null) ? (Integer) defaultValue0 : FALLBACK_DEFAULT_VALUE);
+        setValue(restoreValue ? getPersistedInt(defValue) : defValue);
+    }
+
+    public int getNumColumns() {
+        return numColumns;
+    }
+    private int numColumns = 6;
+
+    public void setValue(int value)
+    {
+        this.value = value;
+        persistInt(this.value);
+        updateSummary();
+    }
+    public int getValue() {
+        return this.value;
+    }
+
+    private String createSummaryString(int value) {
+        return String.format("#%08X", value);
+    }
+
+    private void updateSummary() {
+        setSummary(createSummaryString(getValue()));
+    }
+
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorListPreference.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorListPreference.java
@@ -97,6 +97,7 @@ public class ColorListPreference extends DialogPreference
                     }
                 }
             }
+            numColumns = a.getInt(R.styleable.ColorListPreference_android_numColumns, numColumns);
 
         } finally {
             a.recycle();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorUtils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorUtils.java
@@ -19,6 +19,7 @@
 package com.forrestguice.suntimeswidget.settings.colors;
 
 import android.graphics.Color;
+import android.util.Log;
 
 public class ColorUtils
 {
@@ -31,8 +32,21 @@ public class ColorUtils
     public static boolean isTextReadable(int textColor, int backgroundColor) {
         return getContrastRatio(textColor, backgroundColor) > 4.5;    // AA minimum; https://www.w3.org/TR/WCAG21/#contrast-minimum
     }
-    public static double getLuminance(int color) {
-        return (0.2126 * Color.red(color) + 0.7152 * Color.green(color) + 0.0722 * Color.blue(color));
+
+    /**
+     * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+     */
+    public static double getLuminance(int color)
+    {
+        double r0 = Color.red(color) / 255d;
+        double g0 = Color.green(color) / 255d;
+        double b0 = Color.blue(color) / 255d;
+
+        double r = ((r0 <= 0.04045) ? (r0 / 12.92) : Math.pow((r0 + 0.055) / 1.055, 2.4));
+        double g = ((g0 <= 0.04045) ? (g0 / 12.92) : Math.pow((g0 + 0.055) / 1.055, 2.4));
+        double b = ((b0 <= 0.04045) ? (b0 / 12.92) : Math.pow((b0 + 0.055) / 1.055, 2.4));
+
+        return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
     }
     public static double getContrastRatio(int textColor, int backgroundColor)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorUtils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorUtils.java
@@ -1,0 +1,46 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.settings.colors;
+
+import android.graphics.Color;
+
+public class ColorUtils
+{
+    /**
+     * isTextReadable
+     * @param textColor text color
+     * @param backgroundColor background color
+     * @return contrast ratio between textColor and backgroundColor is greater than 4.5
+     */
+    public static boolean isTextReadable(int textColor, int backgroundColor) {
+        return getContrastRatio(textColor, backgroundColor) > 4.5;    // AA minimum; https://www.w3.org/TR/WCAG21/#contrast-minimum
+    }
+    public static double getLuminance(int color) {
+        return (0.2126 * Color.red(color) + 0.7152 * Color.green(color) + 0.0722 * Color.blue(color));
+    }
+    public static double getContrastRatio(int textColor, int backgroundColor)
+    {
+        double l_textColor = getLuminance(textColor);
+        double l_backgroundColor = getLuminance(backgroundColor);
+        double l1 = Math.max(l_textColor, l_backgroundColor);
+        double l2 = Math.min(l_textColor, l_backgroundColor);
+        return (l1 + 0.05) / (l2 + 0.05);
+    }
+
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorsAdapter.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/ColorsAdapter.java
@@ -18,6 +18,7 @@
 
 package com.forrestguice.suntimeswidget.settings.colors;
 
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -55,6 +56,10 @@ public class ColorsAdapter extends RecyclerView.Adapter<ColorViewHolder>
         notifyDataSetChanged();
     }
 
+    @Nullable
+    public Integer getSelectedColor() {
+        return selectedColor;
+    }
     public void setSelectedColor(int color)
     {
         int newPosition = colors.indexOf(color);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
@@ -92,7 +92,7 @@ public class ColorPickerFragment extends Fragment
     }
 
     public boolean showAlpha() {
-        return getArguments().getBoolean("showAlpha", false);
+        return (colorViewModel != null && colorViewModel.showAlpha());
     }
 
     private final Observer<Integer> onViewModelColorChanged = new Observer<Integer>()
@@ -174,6 +174,7 @@ public class ColorPickerFragment extends Fragment
         public MutableLiveData<Integer> color = new MutableLiveData<>();
         protected Integer color_over = null;
         protected Integer color_under = null;
+        protected boolean showAlpha = false;
 
         public ColorPickerModel() {
             color.setValue(Color.WHITE);
@@ -201,6 +202,13 @@ public class ColorPickerFragment extends Fragment
 
         public void setColor(int value) {
             color.setValue(value);
+        }
+
+        public void setShowAlpha(boolean value) {
+            showAlpha = value;
+        }
+        public boolean showAlpha() {
+            return showAlpha;
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
@@ -154,7 +154,7 @@ public class ColorPickerFragment extends Fragment
                 return String.format(Locale.getDefault(), "%.2f", ColorUtils.getContrastRatio(textColor, backgroundColor));
 
             case ColorPickerModel.PREVIEW_LUMINANCE:
-                return String.format(Locale.getDefault(), "%.2f", 100 * ColorUtils.getLuminance(getColor())) + "%"z;
+                return String.format(Locale.getDefault(), "%.2f", 100 * ColorUtils.getLuminance(getColor())) + "%";
 
             case ColorPickerModel.PREVIEW_TEXT:
             default:

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
@@ -154,7 +154,7 @@ public class ColorPickerFragment extends Fragment
                 return String.format(Locale.getDefault(), "%.2f", ColorUtils.getContrastRatio(textColor, backgroundColor));
 
             case ColorPickerModel.PREVIEW_LUMINANCE:
-                return String.format(Locale.getDefault(), "%.2f", 100 * ColorUtils.getLuminance(getColor()) / 255f) + "%";
+                return String.format(Locale.getDefault(), "%.2f", 100 * ColorUtils.getLuminance(getColor())) + "%"z;
 
             case ColorPickerModel.PREVIEW_TEXT:
             default:

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/colors/pickers/ColorPickerFragment.java
@@ -35,6 +35,9 @@ import android.widget.TextView;
 
 import com.forrestguice.suntimeswidget.R;
 import com.forrestguice.suntimeswidget.settings.colors.ColorChangeListener;
+import com.forrestguice.suntimeswidget.settings.colors.ColorUtils;
+
+import java.util.Locale;
 
 /**
  * ColorPickerFragment
@@ -122,19 +125,41 @@ public class ColorPickerFragment extends Fragment
         if (preview_text != null && colorViewModel.hasColorUnder()) {
             preview_text.setTextColor(getColor());
             preview_text.setBackgroundColor(colorViewModel.getColorUnder());
+            preview_text.setText(getPreviewText(context, getColor(), colorViewModel.getColorUnder()));
 
         } else if (preview_text != null) {
             preview_text.setBackgroundColor(getColor());
             preview_text.setTextColor(getColor());
+            preview_text.setText(getPreviewText(context, getColor(), colorViewModel.getColorUnder()));
         }
 
         if (preview_text1 != null && colorViewModel.hasColorOver()) {
             preview_text1.setTextColor(colorViewModel.getColorOver());
             preview_text1.setBackgroundColor(getColor());
+            preview_text1.setText(getPreviewText(context, colorViewModel.getColorOver(), getColor()));
 
         } else if (preview_text1 != null) {
             preview_text1.setBackgroundColor(getColor());
             preview_text1.setTextColor(getColor());
+            preview_text1.setText(getPreviewText(context, colorViewModel.getColorOver(), getColor()));
+        }
+    }
+
+    @Nullable
+    protected String getPreviewText(Context context, int textColor, int backgroundColor)
+    {
+        switch (colorViewModel.getPreviewMode())
+        {
+            case ColorPickerModel.PREVIEW_CONTRAST_RATIO:
+                return String.format(Locale.getDefault(), "%.2f", ColorUtils.getContrastRatio(textColor, backgroundColor));
+
+            case ColorPickerModel.PREVIEW_LUMINANCE:
+                return String.format(Locale.getDefault(), "%.2f", 100 * ColorUtils.getLuminance(getColor()) / 255f) + "%";
+
+            case ColorPickerModel.PREVIEW_TEXT:
+            default:
+                String text = colorViewModel.getPreviewText();
+                return (text != null) ? text : context.getString(R.string.configLabel_themeColorText);
         }
     }
 
@@ -209,6 +234,26 @@ public class ColorPickerFragment extends Fragment
         }
         public boolean showAlpha() {
             return showAlpha;
+        }
+
+        public static final int PREVIEW_TEXT = 0;
+        public static final int PREVIEW_LUMINANCE = 10;
+        public static final int PREVIEW_CONTRAST_RATIO = 20;
+
+        protected int previewMode = PREVIEW_CONTRAST_RATIO;
+        public int getPreviewMode() {
+            return previewMode;
+        }
+        public void setPreviewMode(int mode) {
+            previewMode = mode;
+        }
+
+        protected String previewText = null;
+        public String getPreviewText() {
+            return previewText;
+        }
+        public void setPreviewText(String value) {
+            previewText = value;
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
@@ -59,10 +59,9 @@ import com.forrestguice.suntimeswidget.alarmclock.AlarmSettings;
 import com.forrestguice.suntimeswidget.alarmclock.bedtime.BedtimeSettings;
 import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValues;
 import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValuesCollection;
-import com.forrestguice.suntimeswidget.colors.ColorValuesSheetActivity;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
 import com.forrestguice.suntimeswidget.settings.SettingsActivityInterface;
-import com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference;
+import com.forrestguice.suntimeswidget.colors.ColorValuesCollectionPreference;
 import com.forrestguice.suntimeswidget.views.Toast;
 
 import static com.forrestguice.suntimeswidget.settings.AppSettings.findPermission;
@@ -241,7 +240,7 @@ public class AlarmPrefsFragment extends PreferenceFragment
             volumesPrefs.setOnPreferenceClickListener(onVolumesPrefsClicked(context));
         }
 
-        final ColorCollectionPreference brightColorsPref = (ColorCollectionPreference) fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BRIGHTMODE_COLORS);
+        final ColorValuesCollectionPreference brightColorsPref = (ColorValuesCollectionPreference) fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BRIGHTMODE_COLORS);
         if (brightColorsPref != null)
         {
             brightColorsPref.setCollection(context, new BrightAlarmColorValuesCollection<BrightAlarmColorValues>(context));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
@@ -62,6 +62,7 @@ import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValu
 import com.forrestguice.suntimeswidget.colors.ColorValuesSheetActivity;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
 import com.forrestguice.suntimeswidget.settings.SettingsActivityInterface;
+import com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference;
 import com.forrestguice.suntimeswidget.views.Toast;
 
 import static com.forrestguice.suntimeswidget.settings.AppSettings.findPermission;
@@ -240,35 +241,11 @@ public class AlarmPrefsFragment extends PreferenceFragment
             volumesPrefs.setOnPreferenceClickListener(onVolumesPrefsClicked(context));
         }
 
-        final Preference brightColorsPref = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BRIGHTMODE_COLORS);
+        final ColorCollectionPreference brightColorsPref = (ColorCollectionPreference) fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BRIGHTMODE_COLORS);
         if (brightColorsPref != null)
         {
-            final int appWidgetID = 0;
-            final String colorTag = BrightAlarmColorValues.TAG_ALARMCOLORS;
-            final BrightAlarmColorValuesCollection<BrightAlarmColorValues> colorValues = new BrightAlarmColorValuesCollection<BrightAlarmColorValues>(context);
-            String selectedColorsID = colorValues.getSelectedColorsID(context, appWidgetID, colorTag);
-
-            brightColorsPref.setSummary(context.getString(R.string.configLabel_alarms_brightMode_colors_summary, (selectedColorsID != null ? selectedColorsID : context.getString(R.string.configLabel_tagDefault))));
-            brightColorsPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener()
-            {
-                @Override
-                public boolean onPreferenceClick(Preference preference)
-                {
-                    Activity activity = fragment.getActivity();
-                    if (activity != null)
-                    {
-                        Intent intent = new Intent(activity, ColorValuesSheetActivity.class);
-                        intent.putExtra(ColorValuesSheetActivity.EXTRA_APPWIDGET_ID, appWidgetID);
-                        intent.putExtra(ColorValuesSheetActivity.EXTRA_COLORTAG, colorTag);
-                        intent.putExtra(ColorValuesSheetActivity.EXTRA_COLLECTION, colorValues);
-                        intent.putExtra(ColorValuesSheetActivity.EXTRA_TITLE, brightColorsPref.getTitle());
-                        intent.putExtra(ColorValuesSheetActivity.EXTRA_SHOW_ALPHA, true);
-                        activity.startActivityForResult(intent, SettingsActivityInterface.REQUEST_PICKCOLORS_BRIGHTALARM);
-                        activity.overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);
-                    }
-                    return false;
-                }
-            });
+            brightColorsPref.setCollection(context, new BrightAlarmColorValuesCollection<BrightAlarmColorValues>(context));
+            brightColorsPref.initPreferenceOnClickListener(fragment.getActivity(), SettingsActivityInterface.REQUEST_PICKCOLORS_BRIGHTALARM);
         }
 
         Preference powerOffAlarmsPref = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_POWEROFFALARMS);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/AlarmPrefsFragment.java
@@ -57,7 +57,11 @@ import com.forrestguice.suntimeswidget.alarmclock.AlarmClockItem;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmNotifications;
 import com.forrestguice.suntimeswidget.alarmclock.AlarmSettings;
 import com.forrestguice.suntimeswidget.alarmclock.bedtime.BedtimeSettings;
+import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValues;
+import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValuesCollection;
+import com.forrestguice.suntimeswidget.colors.ColorValuesSheetActivity;
 import com.forrestguice.suntimeswidget.settings.AppSettings;
+import com.forrestguice.suntimeswidget.settings.SettingsActivityInterface;
 import com.forrestguice.suntimeswidget.views.Toast;
 
 import static com.forrestguice.suntimeswidget.settings.AppSettings.findPermission;
@@ -234,6 +238,37 @@ public class AlarmPrefsFragment extends PreferenceFragment
         Preference volumesPrefs = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_VOLUMES);
         if (volumesPrefs != null) {
             volumesPrefs.setOnPreferenceClickListener(onVolumesPrefsClicked(context));
+        }
+
+        final Preference brightColorsPref = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_BRIGHTMODE_COLORS);
+        if (brightColorsPref != null)
+        {
+            final int appWidgetID = 0;
+            final String colorTag = BrightAlarmColorValues.TAG_ALARMCOLORS;
+            final BrightAlarmColorValuesCollection<BrightAlarmColorValues> colorValues = new BrightAlarmColorValuesCollection<BrightAlarmColorValues>(context);
+            String selectedColorsID = colorValues.getSelectedColorsID(context, appWidgetID, colorTag);
+
+            brightColorsPref.setSummary(context.getString(R.string.configLabel_alarms_brightMode_colors_summary, (selectedColorsID != null ? selectedColorsID : context.getString(R.string.configLabel_tagDefault))));
+            brightColorsPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener()
+            {
+                @Override
+                public boolean onPreferenceClick(Preference preference)
+                {
+                    Activity activity = fragment.getActivity();
+                    if (activity != null)
+                    {
+                        Intent intent = new Intent(activity, ColorValuesSheetActivity.class);
+                        intent.putExtra(ColorValuesSheetActivity.EXTRA_APPWIDGET_ID, appWidgetID);
+                        intent.putExtra(ColorValuesSheetActivity.EXTRA_COLORTAG, colorTag);
+                        intent.putExtra(ColorValuesSheetActivity.EXTRA_COLLECTION, colorValues);
+                        intent.putExtra(ColorValuesSheetActivity.EXTRA_TITLE, brightColorsPref.getTitle());
+                        intent.putExtra(ColorValuesSheetActivity.EXTRA_SHOW_ALPHA, true);
+                        activity.startActivityForResult(intent, SettingsActivityInterface.REQUEST_PICKCOLORS_BRIGHTALARM);
+                        activity.overridePendingTransition(R.anim.transition_next_in, R.anim.transition_next_out);
+                    }
+                    return false;
+                }
+            });
         }
 
         Preference powerOffAlarmsPref = fragment.findPreference(AlarmSettings.PREF_KEY_ALARM_POWEROFFALARMS);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/LocalePrefsFragment.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/settings/fragments/LocalePrefsFragment.java
@@ -27,6 +27,7 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
+import android.support.v4.util.Pair;
 import android.util.Log;
 
 import com.forrestguice.suntimeswidget.R;
@@ -65,7 +66,7 @@ public class LocalePrefsFragment extends PreferenceFragment
         initPref_locale(fragment.getActivity(), localeModePref, localePref);
     }
 
-   public static void initPref_locale(final Activity activity, Preference localeModePref, ListPreference localePref)
+    public static Pair<CharSequence[], CharSequence[]> getEntries(final Activity activity)
     {
         final String[] localeDisplay = activity.getResources().getStringArray(R.array.locale_display);
         final String[] localeDisplayNative = activity.getResources().getStringArray(R.array.locale_display_native);
@@ -93,9 +94,14 @@ public class LocalePrefsFragment extends PreferenceFragment
             entries[i] = formattedDisplayString;
             values[i] = localeValues[j];
         }
+        return new Pair<>(entries, values);
+    }
 
-        localePref.setEntries(entries);
-        localePref.setEntryValues(values);
+    public static void initPref_locale(final Activity activity, Preference localeModePref, ListPreference localePref)
+    {
+        Pair<CharSequence[], CharSequence[]> a = getEntries(activity);
+        localePref.setEntries(a.first);
+        localePref.setEntryValues(a.second);
 
         AppSettings.LocaleMode localeMode = AppSettings.loadLocaleModePref(activity);
         localePref.setEnabled(localeMode == AppSettings.LocaleMode.CUSTOM_LOCALE);

--- a/app/src/main/res/layout-land/layout_dialog_colors.xml
+++ b/app/src/main/res/layout-land/layout_dialog_colors.xml
@@ -28,12 +28,24 @@
         android:paddingLeft="?dialogPreferredPadding" android:paddingRight="?dialogPreferredPadding"
         android:paddingTop="8dp" android:paddingBottom="8dp">
 
-        <TextView
-            android:id="@+id/dialog_title"
+        <LinearLayout
             android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1"
-            android:gravity="start"
-            style="@style/Base.DialogWindowTitle.AppCompat"
-            android:text="@string/color_dialog_msg" />
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/dialog_title"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:gravity="start"
+                style="@style/Base.DialogWindowTitle.AppCompat"
+                android:text="@string/color_dialog_msg" />
+
+            <TextView
+                android:id="@+id/dialog_subtitle" android:visibility="gone"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:gravity="start" style="@style/DialogSubTitleStyle"
+                tools:text="Background" />
+
+        </LinearLayout>
 
         <android.support.design.widget.TabLayout
             android:id="@+id/color_pager_tabs" android:visibility="visible"

--- a/app/src/main/res/layout/fragment_colorvalues.xml
+++ b/app/src/main/res/layout/fragment_colorvalues.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout android:id="@+id/layout_header" android:orientation="horizontal"
         android:layout_width="match_parent" android:layout_height="wrap_content"
@@ -10,16 +13,16 @@
         <ImageButton android:id="@+id/cancelButton"
             style="@style/Widget.AppCompat.ActionButton" android:src="?attr/icActionBack"
             android:layout_width="wrap_content" android:layout_height="wrap_content"
-            android:tooltipText="@android:string/cancel"
+            android:tooltipText="@string/dialog_cancel"
             android:contentDescription="@android:string/cancel" />
 
-        <EditText android:id="@+id/editTextID"
+        <EditText android:id="@+id/editTextLabel"
             android:layout_width="0dp" android:layout_weight="1"
             android:layout_height="wrap_content"
             android:layout_marginLeft="8dp" android:layout_marginRight="0dp"
             android:layout_marginStart="8dp" android:layout_marginEnd="0dp"
             android:inputType="text"
-            android:hint="@string/hint_colorid" android:textSize="?attr/text_size_medium"
+            android:hint="@string/hint_colorlabel" android:textSize="?attr/text_size_medium"
             android:importantForAutofill="no" />
 
         <ImageButton android:id="@+id/saveButton"
@@ -42,14 +45,39 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <GridLayout android:id="@+id/colorPanel" android:columnCount="2"
+        <LinearLayout
             android:layout_width="match_parent" android:layout_height="wrap_content"
-            android:orientation="vertical" android:gravity="top|start"
-            android:useDefaultMargins="false"
-            android:layout_marginLeft="16dp" android:layout_marginRight="16dp"
-            android:layout_marginTop="4dp" android:layout_marginBottom="8dp">
+            android:orientation="vertical">
 
-        </GridLayout>
+            <GridLayout android:id="@+id/colorPanel" android:columnCount="2"
+                android:layout_width="match_parent" android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:orientation="vertical" android:gravity="top|start"
+                android:layout_marginLeft="16dp" android:layout_marginRight="16dp"
+                android:layout_marginTop="4dp" android:layout_marginBottom="8dp"
+                android:useDefaultMargins="false" />
+
+            <LinearLayout android:orientation="horizontal"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:layout_marginLeft="16dp" android:layout_marginRight="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content" android:layout_height="wrap_content"
+                    android:labelFor="@+id/editTextID"
+                    android:textSize="?attr/text_size_small"
+                    android:text="@string/configLabel_themeID" />
+
+                <EditText android:id="@+id/editTextID"
+                    android:layout_width="wrap_content" android:layout_height="wrap_content" android:minWidth="200dp"
+                    android:inputType="text" tools:text="ID"
+                    android:hint="@string/hint_colorid" android:textSize="?attr/text_size_small"
+                    android:layout_marginLeft="8dp" android:layout_marginRight="8dp"
+                    android:importantForAutofill="no" />
+
+            </LinearLayout>
+
+        </LinearLayout>
 
     </ScrollView>
 

--- a/app/src/main/res/layout/fragment_colorvalues.xml
+++ b/app/src/main/res/layout/fragment_colorvalues.xml
@@ -19,7 +19,7 @@
             android:layout_marginLeft="8dp" android:layout_marginRight="0dp"
             android:layout_marginStart="8dp" android:layout_marginEnd="0dp"
             android:inputType="text"
-            android:hint="@string/hint_colorid" android:textSize="?attr/text_size_small"
+            android:hint="@string/hint_colorid" android:textSize="?attr/text_size_medium"
             android:importantForAutofill="no" />
 
         <ImageButton android:id="@+id/saveButton"

--- a/app/src/main/res/layout/layout_activity_colorsheet.xml
+++ b/app/src/main/res/layout/layout_activity_colorsheet.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+
+    <android.support.design.widget.CoordinatorLayout android:id="@+id/layout_background"
+        android:layout_width="match_parent" android:layout_height="match_parent" android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" android:orientation="vertical">
+
+            <android.support.design.widget.AppBarLayout
+                android:id="@+id/layout_app_menubar"
+                android:layout_width="match_parent" android:layout_height="wrap_content">
+
+                <android.support.v7.widget.Toolbar
+                    android:id="@+id/app_menubar" style="@style/AppToolbarStyle"
+                    app:title="@string/configAction_colors"
+                    app:popupTheme="?attr/actionBarPopupTheme" />
+
+            </android.support.design.widget.AppBarLayout>
+
+            <LinearLayout android:id="@+id/fragmentContainer"
+                android:layout_width="match_parent" android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+
+    </android.support.design.widget.CoordinatorLayout>
+</merge>

--- a/app/src/main/res/layout/layout_activity_dismissalarm.xml
+++ b/app/src/main/res/layout/layout_activity_dismissalarm.xml
@@ -173,7 +173,7 @@
 		<TextView android:id="@+id/txt_snooze" android:visibility="visible"
 			style="@style/TextAppearance.AppCompat.Small"
 			android:layout_width="0dp" android:layout_height="wrap_content"
-			android:gravity="center"
+			android:gravity="end" android:layout_marginLeft="16dp" android:layout_marginRight="16dp"
 			app:layout_constraintStart_toEndOf="@+id/layout_back" android:layout_marginBottom="@dimen/alarmdismiss_margin"
 			app:layout_constraintEnd_toEndOf="parent"
 			app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/layout_activity_welcome.xml
+++ b/app/src/main/res/layout/layout_activity_welcome.xml
@@ -8,9 +8,11 @@
 
     <LinearLayout android:id="@+id/indicator_layout"
         android:layout_width="match_parent" android:layout_height="wrap_content"
+        android:minHeight="24dp"
         app:layout_constraintTop_toTopOf="@+id/button_next"
         app:layout_constraintBottom_toBottomOf="@+id/button_next"
-        android:orientation="horizontal" android:gravity="center" />
+        android:orientation="horizontal" android:gravity="center"
+        android:background="?attr/dialogBackgroundAlt" />
 
     <View
         android:layout_width="match_parent" android:layout_height="1dp"

--- a/app/src/main/res/layout/layout_dialog_colors.xml
+++ b/app/src/main/res/layout/layout_dialog_colors.xml
@@ -28,12 +28,24 @@
         android:paddingLeft="?dialogPreferredPadding" android:paddingRight="?dialogPreferredPadding"
         android:paddingTop="16dp" android:paddingBottom="16dp">
 
-        <TextView
-            android:id="@+id/dialog_title"
-            android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1"
-            android:gravity="start"
-            style="@style/Base.DialogWindowTitle.AppCompat"
-            android:text="@string/color_dialog_msg" />
+        <LinearLayout
+            android:layout_width="0dp" android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/dialog_title"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:gravity="start" style="@style/Base.DialogWindowTitle.AppCompat"
+                android:text="@string/color_dialog_msg" />
+
+            <TextView
+                android:id="@+id/dialog_subtitle" android:visibility="gone"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:gravity="start" style="@style/DialogSubTitleStyle"
+                tools:text="Background" />
+
+        </LinearLayout>
 
         <android.support.design.widget.TabLayout
             android:id="@+id/color_pager_tabs" android:visibility="visible"

--- a/app/src/main/res/layout/layout_listitem_color2.xml
+++ b/app/src/main/res/layout/layout_listitem_color2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content" android:layout_height="wrap_content"
+    android:id="@+id/colorButtonFrame">
+
+    <ImageButton
+        android:id="@+id/colorButton"
+        style="@style/ColorEditButton3" android:contentDescription="@string/configAction_chooseColor" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/layout_listitem_colors.xml
+++ b/app/src/main/res/layout/layout_listitem_colors.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent" android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:orientation="horizontal" android:gravity="center_vertical"
+    android:paddingStart="8dp" android:paddingEnd="8dp">
+
+    <View
+        android:id="@+id/colorPreview0"
+        android:layout_width="32dp" android:layout_height="match_parent"
+        android:layout_marginTop="8dp" android:layout_marginBottom="8dp"
+        android:background="@color/indigo_100" />
+
+    <View
+        android:id="@+id/colorPreview1"
+        android:layout_width="16dp" android:layout_height="match_parent"
+        android:layout_marginTop="8dp" android:layout_marginBottom="8dp"
+        android:background="@color/indigo_200" />
+
+    <View
+        android:id="@+id/colorPreview2"
+        android:layout_width="16dp" android:layout_height="match_parent"
+        android:layout_marginTop="8dp" android:layout_marginBottom="8dp"
+        android:background="@color/indigo_300" />
+
+    <TextView android:id="@android:id/text1" android:layout_margin="8dp"
+        android:layout_width="wrap_content" android:layout_height="wrap_content"
+        android:textSize="?attr/text_size_medium" android:textStyle="bold"
+        tools:text="Color Text" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/layout_pref_action.xml
+++ b/app/src/main/res/layout/layout_pref_action.xml
@@ -3,15 +3,13 @@
     android:layout_width="wrap_content" android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:gravity="center"
-    android:background="?attr/selectableItemBackground" >
+    android:background="?attr/selectableItemBackground">
 
     <ImageView
         android:id="@+id/actionButton0"
         style="@style/Widget.AppCompat.ActionButton"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
-        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:layout_width="64dp" android:layout_height="match_parent"
+        android:paddingLeft="?android:attr/scrollbarSize" android:paddingRight="?android:attr/scrollbarSize"
         android:src="?attr/icActionExtension" android:contentDescription="@string/configAction_editAction" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/layout_pref_color.xml
+++ b/app/src/main/res/layout/layout_pref_color.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/colorPreview"
+    android:layout_width="32dp" android:layout_height="32dp"
+    android:background="@color/indigo_a100"
+    android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
+    android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+    android:contentDescription="@string/configAction_chooseColor" />

--- a/app/src/main/res/layout/layout_pref_colors.xml
+++ b/app/src/main/res/layout/layout_pref_colors.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content" android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <View
+        android:id="@+id/colorPreview0"
+        android:layout_width="32dp" android:layout_height="32dp"
+        android:background="@color/indigo_a100"
+        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
+        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:contentDescription="@string/configAction_chooseColor" />
+
+    <View
+        android:id="@+id/colorPreview1"
+        android:layout_width="16dp" android:layout_height="32dp"
+        android:background="@color/indigo_a200"
+        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
+        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:contentDescription="@string/configAction_chooseColor" />
+
+    <View
+        android:id="@+id/colorPreview2"
+        android:layout_width="16dp" android:layout_height="32dp"
+        android:background="@color/indigo_a400"
+        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
+        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:contentDescription="@string/configAction_chooseColor" />
+
+    <!-- <View
+        android:id="@+id/colorPreview3"
+        android:layout_width="16dp" android:layout_height="32dp"
+        android:background="@color/indigo_100"
+        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
+        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:contentDescription="@string/configAction_chooseColor" />
+
+    <View
+        android:id="@+id/colorPreview4"
+        android:layout_width="16dp" android:layout_height="32dp"
+        android:background="@color/indigo_200"
+        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
+        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:contentDescription="@string/configAction_chooseColor" /> -->
+
+</LinearLayout>

--- a/app/src/main/res/layout/layout_pref_themewidget.xml
+++ b/app/src/main/res/layout/layout_pref_themewidget.xml
@@ -8,10 +8,8 @@
     <ImageView
         android:id="@+id/actionButton0"
         style="@style/Widget.AppCompat.ActionButton"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingLeft="64dp" android:paddingRight="?android:attr/scrollbarSize"
-        android:paddingStart="64dp" android:paddingEnd="?android:attr/scrollbarSize"
+        android:layout_width="64dp" android:layout_height="match_parent"
+        android:paddingLeft="?android:attr/scrollbarSize" android:paddingRight="?android:attr/scrollbarSize"
         android:src="?attr/icActionAppearance" android:contentDescription="@string/configAction_editTheme" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/layout_view_alarmbutton.xml
+++ b/app/src/main/res/layout/layout_view_alarmbutton.xml
@@ -5,23 +5,34 @@
     android:layout_width="match_parent" android:layout_height="match_parent" android:minWidth="175dp"
     android:layout_gravity="center">
 
-    <TextView android:id="@+id/layout_drag_hint_top"
+    <FrameLayout android:id="@+id/layout_drag_hint_top"
         android:layout_width="wrap_content" android:layout_height="wrap_content"
-        android:text="@string/drag_hint"
-        android:textSize="?attr/text_size_tiny" android:textColor="?attr/text_accentColor"
-        android:textStyle="bold"
-        android:gravity="center"
         android:layout_gravity="top|center_horizontal"
-        android:rotation="0" />
+        android:clipChildren="false">
 
-    <TextView android:id="@+id/layout_drag_hint_bottom"
+        <TextView android:id="@+id/text_drag_hint_top"
+            android:layout_width="100dp" android:layout_height="wrap_content"
+            android:text="@string/drag_hint"
+            android:textSize="?attr/text_size_tiny" android:textColor="?attr/text_accentColor"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:rotation="0" />
+    </FrameLayout>
+
+    <FrameLayout android:id="@+id/layout_drag_hint_bottom"
         android:layout_width="wrap_content" android:layout_height="wrap_content"
-        android:text="@string/drag_hint"
-        android:textSize="?attr/text_size_tiny" android:textColor="?attr/text_accentColor"
-        android:textStyle="bold"
-        android:gravity="center"
         android:layout_gravity="bottom|center_horizontal"
-        android:rotation="0" />
+        android:clipChildren="false">
+
+        <TextView android:id="@+id/text_drag_hint_bottom"
+            android:layout_width="100dp" android:layout_height="wrap_content"
+            android:text="@string/drag_hint"
+            android:textSize="?attr/text_size_tiny" android:textColor="?attr/text_accentColor"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:rotation="0" />
+
+    </FrameLayout>
 
     <FrameLayout android:id="@+id/layout_drag_hint_start"
         android:layout_width="32dp" android:layout_height="wrap_content"

--- a/app/src/main/res/layout/layout_welcome_ui.xml
+++ b/app/src/main/res/layout/layout_welcome_ui.xml
@@ -1,43 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical" android:gravity="center"
-    android:layout_width="match_parent" android:layout_height="match_parent"
-    android:paddingBottom="48dp" android:background="?attr/dialogBackgroundAlt">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/scroll" android:layout_width="match_parent" android:layout_height="wrap_content">
 
-    <LinearLayout android:id="@+id/header"
-        android:layout_width="match_parent" android:layout_height="wrap_content"
+    <android.support.constraint.ConstraintLayout
         android:orientation="vertical" android:gravity="center"
-        android:layout_margin="16dp"
-        app:layout_constraintStart_toStartOf="parent" app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/scroll"
-        app:layout_constraintVertical_chainStyle="packed">
-
-        <android.support.v7.widget.AppCompatImageView
-            android:id="@+id/icon" android:layout_marginTop="8dp"
-            android:layout_width="96dp" android:layout_height="96dp" android:scaleType="fitCenter"
-            android:src="@drawable/ic_settings_128dp" app:tint="?attr/colorControlNormal"
-            tools:ignore="ContentDescription" />
-
-        <TextView android:id="@+id/text_title"
-            android:layout_height="wrap_content" android:layout_width="wrap_content"
-            android:gravity="start" android:layout_margin="8dp"
-            android:textAppearance="?android:attr/textAppearanceLarge" android:textSize="?attr/text_size_xlarge"
-            android:textColor="?attr/date_buttonSelector" android:textStyle="bold"
-            android:text="@string/configLabel_ui" />
-
-    </LinearLayout>
-
-    <ScrollView android:id="@+id/scroll"
         android:layout_width="match_parent" android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/header"
-        app:layout_constraintBottom_toBottomOf="parent">
+        android:paddingBottom="48dp" android:background="?attr/dialogBackgroundAlt">
+
+        <LinearLayout android:id="@+id/header"
+            android:layout_width="match_parent" android:layout_height="wrap_content"
+            android:orientation="vertical" android:gravity="center"
+            android:layout_margin="16dp"
+            app:layout_constraintStart_toStartOf="parent" app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/options_layout"
+            app:layout_constraintVertical_chainStyle="packed">
+
+            <android.support.v7.widget.AppCompatImageView
+                android:id="@+id/icon" android:layout_marginTop="8dp"
+                android:layout_width="96dp" android:layout_height="96dp" android:scaleType="fitCenter"
+                android:src="@drawable/ic_settings_128dp" app:tint="?attr/colorControlNormal"
+                tools:ignore="ContentDescription" />
+
+            <TextView android:id="@+id/text_title"
+                android:layout_height="wrap_content" android:layout_width="wrap_content"
+                android:gravity="start" android:layout_margin="8dp"
+                android:textAppearance="?android:attr/textAppearanceLarge" android:textSize="?attr/text_size_xlarge"
+                android:textColor="?attr/date_buttonSelector" android:textStyle="bold"
+                android:text="@string/configLabel_ui" />
+
+        </LinearLayout>
 
         <LinearLayout android:id="@+id/options_layout" android:orientation="vertical"
             android:layout_width="match_parent" android:layout_height="wrap_content"
             android:layout_marginLeft="16dp" android:layout_marginRight="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="48dp">
+            android:layout_marginTop="16dp" android:layout_marginBottom="48dp"
+            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/header"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <TextView
                 android:layout_height="wrap_content" android:layout_width="wrap_content"
@@ -108,8 +107,5 @@
 
         </LinearLayout>
 
-    </ScrollView>
-
-
-
-</android.support.constraint.ConstraintLayout>
+    </android.support.constraint.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/menu/menu_colorsheet.xml
+++ b/app/src/main/res/menu/menu_colorsheet.xml
@@ -1,0 +1,34 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="com.forrestguice.suntimes.naturalhour.MainActivity">
+
+    <item
+        android:id="@+id/action_colors_select"
+        android:orderInCategory="10"
+        android:icon="?attr/icActionAccept"
+        android:title="@string/configAction_chooseColor"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_colors_import"
+        android:orderInCategory="200"
+        android:icon="?attr/icActionNew"
+        android:title="@string/configAction_importColors"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_colors_share"
+        android:orderInCategory="300"
+        android:icon="?attr/icActionShare"
+        android:title="@string/configAction_share"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_colors_delete"
+        android:orderInCategory="400"
+        android:icon="?attr/icActionDelete"
+        android:title="@string/configAction_deleteColors"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -35,6 +35,7 @@
     <color name="text_disabled">@color/text_disabled_dark</color>
     <color name="text_accent">@color/text_accent_dark</color>
     <color name="text_primary">@color/text_primary_dark</color>
+    <color name="text_primary_inverse">@color/text_primary_inverse_dark</color>
     <color name="text_secondary">@color/text_secondary_dark</color>
     <color name="text_tertiary">@color/text_tertiary_dark</color>
     <color name="text_time">@color/text_time_dark</color>

--- a/app/src/main/res/values/alarm_res.xml
+++ b/app/src/main/res/values/alarm_res.xml
@@ -51,4 +51,74 @@
     <dimen name="clockcard_corners">4dp</dimen>
     <dimen name="clockcard_corners_controls">8dp</dimen>
 
+    <integer-array name="alarm_bright_colors_list">
+        <item>@color/white</item>
+        <item>@color/blue_grey_100</item>
+        <item>@color/brown_100</item>
+
+        <item>@color/yellow_a100</item>
+        <item>@color/yellow_a200</item>
+        <item>@color/yellow_a400</item>
+
+        <item>@color/lime_a100</item>
+        <item>@color/lime_a200</item>
+        <item>@color/lime_a400</item>
+
+        <item>@color/light_green_a100</item>
+        <item>@color/light_green_a200</item>
+        <item>@color/light_green_a400</item>
+
+        <item>@color/green_a100</item>
+        <item>@color/green_a200</item>
+        <item>@color/green_a400</item>
+
+        <item>@color/teal_a100</item>
+        <item>@color/teal_a200</item>
+        <item>@color/teal_a400</item>
+
+        <item>@color/cyan_a100</item>
+        <item>@color/cyan_a200</item>
+        <item>@color/cyan_a400</item>
+
+        <item>@color/light_blue_a100</item>
+        <item>@color/light_blue_a200</item>
+        <item>@color/light_blue_a400</item>
+
+        <item>@color/blue_a100</item>
+        <item>@color/blue_a200</item>
+        <item>@color/blue_a400</item>
+
+        <item>@color/indigo_a100</item>
+        <item>@color/indigo_a200</item>
+        <item>@color/indigo_a400</item>
+
+        <item>@color/deep_purple_a100</item>
+        <item>@color/deep_purple_a200</item>
+        <item>@color/deep_purple_a400</item>
+
+        <item>@color/purple_a100</item>
+        <item>@color/purple_a200</item>
+        <item>@color/purple_a400</item>
+
+        <item>@color/pink_a100</item>
+        <item>@color/pink_a200</item>
+        <item>@color/pink_a400</item>
+
+        <item>@color/red_a100</item>
+        <item>@color/red_a200</item>
+        <item>@color/red_a400</item>
+
+        <item>@color/deep_orange_a100</item>
+        <item>@color/deep_orange_a200</item>
+        <item>@color/deep_orange_a400</item>
+
+        <item>@color/orange_a100</item>
+        <item>@color/orange_a200</item>
+        <item>@color/orange_a400</item>
+
+        <item>@color/amber_a100</item>
+        <item>@color/amber_a200</item>
+        <item>@color/amber_a400</item>
+    </integer-array>
+
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -269,6 +269,10 @@
         <attr name="zeroValueText" />
     </declare-styleable>
 
+    <declare-styleable name="ColorListPreference">
+        <attr name="colorValues" format="reference" />
+    </declare-styleable>
+
     <declare-styleable name="HelpPreference">
         <attr name="helpText" format="string" />
         <attr name="helpLink" format="string" />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -278,6 +278,14 @@
         <attr name="android:numColumns" />
     </declare-styleable>
 
+    <declare-styleable name="ColorCollectionPreference">
+        <attr name="colorTag" format="string" />
+        <attr name="appWidgetID" format="integer" />
+        <attr name="showAlpha" format="boolean" />
+        <attr name="previewKeys" format="reference" />
+        <attr name="android:summary" />
+    </declare-styleable>
+
     <declare-styleable name="HelpPreference">
         <attr name="helpText" format="string" />
         <attr name="helpLink" format="string" />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -269,6 +269,10 @@
         <attr name="zeroValueText" />
     </declare-styleable>
 
+    <declare-styleable name="ActionButtonPreference">
+        <attr name="actionButtonContentDescription" format="string" />
+    </declare-styleable>
+
     <declare-styleable name="ColorListPreference">
         <attr name="colorValues" format="reference" />
     </declare-styleable>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -275,6 +275,7 @@
 
     <declare-styleable name="ColorListPreference">
         <attr name="colorValues" format="reference" />
+        <attr name="android:numColumns" />
     </declare-styleable>
 
     <declare-styleable name="HelpPreference">

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -16,6 +16,7 @@
     <attr name="hrColor" format="reference" />
 
     <attr name="text_primaryColor" format="reference" />
+    <attr name="text_primaryInverseColor" format="reference" />
     <attr name="text_secondaryColor" format="reference" />
     <attr name="text_tertiaryColor" format="reference" />
     <attr name="text_accentColor" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -44,6 +44,7 @@
     <color name="text_disabled">@color/text_disabled_light</color>
     <color name="text_accent">@color/text_accent_light</color>
     <color name="text_primary">@color/text_primary_light</color>
+    <color name="text_primary_inverse">@color/text_primary_inverse_light</color>
     <color name="text_secondary">@color/text_secondary_light</color>
     <color name="text_tertiary">@color/text_tertiary_light</color>
     <color name="text_time">@color/text_time_light</color>
@@ -133,6 +134,7 @@
     <!-- general -->
 
     <color name="text_primary_dark">@android:color/primary_text_dark</color>
+    <color name="text_primary_inverse_dark">@android:color/primary_text_light</color>
     <color name="text_secondary_dark">@android:color/secondary_text_dark</color>
     <color name="text_tertiary_dark">@android:color/tertiary_text_dark</color>
     <color name="text_time_dark">@android:color/primary_text_dark</color>
@@ -168,6 +170,7 @@
     <color name="table_moon_setting_dark">@color/moonIcon_color_setting_dark</color>
 
     <color name="text_primary_light">@android:color/primary_text_light</color>
+    <color name="text_primary_inverse_light">@android:color/primary_text_dark</color>
     <color name="text_secondary_light">@android:color/secondary_text_light</color>
     <color name="text_tertiary_light">@android:color/tertiary_text_light</color>
     <color name="text_time_light">@android:color/primary_text_light</color>

--- a/app/src/main/res/values/colors_md2.xml
+++ b/app/src/main/res/values/colors_md2.xml
@@ -32,8 +32,8 @@
         <item>@color/grey_900</item>
         <item>@color/grey_999</item>
         <item>@color/grey_999</item>
-        <item>@color/grey_999</item>
-        <item>@color/grey_999</item>
+        <item>@color/white</item>
+        <item>@color/black</item>
     </integer-array>
 
     <color name="brown_50">#FFEFEBE9</color>

--- a/app/src/main/res/values/colors_md2.xml
+++ b/app/src/main/res/values/colors_md2.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <color name="dark_text_high">#DEFFFFFF</color>      // 87%
+    <color name="dark_text_medium">#99FFFFFF</color>    // 60%
+    <color name="dark_text_disabled">#61FFFFFF</color>  // 38%
+
+    <color name="light_text_high">#DE000000</color>      // 87%
+    <color name="light_text_medium">#99000000</color>    // 60%
+    <color name="light_text_disabled">#61000000</color>  // 38%
+
     <color name="transparent">#00000000</color>
     <color name="white">#ffffffff</color>
     <color name="black">#ff000000</color>
@@ -46,6 +54,7 @@
     <color name="brown_700">#FF5D4037</color>
     <color name="brown_800">#FF4E342E</color>
     <color name="brown_900">#FF3E2723</color>
+    <color name="brown_999">#FF180704</color>
 
     <integer-array name="material_brown">
         <item>@color/brown_50</item>
@@ -61,7 +70,7 @@
         <item>@color/brown_900</item>
         <item>@color/brown_900</item>
         <item>@color/brown_900</item>
-        <item>@color/brown_900</item>
+        <item>@color/brown_999</item>
     </integer-array>
 
     <color name="blue_grey_50">#FFECEFF1</color>
@@ -74,6 +83,7 @@
     <color name="blue_grey_700">#FF455A64</color>
     <color name="blue_grey_800">#FF37474F</color>
     <color name="blue_grey_900">#FF263238</color>
+    <color name="blue_grey_999">#FF151B1E</color>
 
     <integer-array name="material_blue_grey">
         <item>@color/blue_grey_50</item>
@@ -89,7 +99,7 @@
         <item>@color/blue_grey_900</item>
         <item>@color/blue_grey_900</item>
         <item>@color/blue_grey_900</item>
-        <item>@color/blue_grey_900</item>
+        <item>@color/blue_grey_999</item>
     </integer-array>
 
     <color name="cyan_50">#FFE0F7FA</color>

--- a/app/src/main/res/values/pref_defaults.xml
+++ b/app/src/main/res/values/pref_defaults.xml
@@ -52,8 +52,10 @@
     <string name="def_app_alarms_snooze" translatable="false">600000</string>      <!-- snooze for 10m -->
     <string name="def_app_alarms_snoozeLimit" translatable="false">0</string>      <!-- no snooze limit -->
     <string name="def_app_alarms_upcoming" translatable="false">36000000</string>  <!-- show reminder within 10h -->
-    <bool name="def_app_alarms_bright" translatable="false">false</bool>       <!-- bright mode alarms -->
-    <string name="def_app_alarms_bright_fadein" translatable="false">60000</string>       <!-- bright mode fade in 60s -->
+    <bool name="def_app_alarms_bright" translatable="false">false</bool>                            <!-- bright mode alarms -->
+    <string name="def_app_alarms_bright_fadein" translatable="false">60000</string>                 <!-- alarm bright mode fade in 60s -->
+    <color name="def_app_alarms_bright_color_start" translatable="false">@color/black</color>       <!-- alarm bright mode start color -->
+    <color name="def_app_alarms_bright_color_end" translatable="false">@color/white</color>         <!-- alarm bright mode end color -->
     <string name="def_app_alarms_fadein" translatable="false">10000</string>       <!-- fade-in 10s to full volume -->
     <string name="def_app_alarms_hardwarebuttons_action" translatable="false">suntimeswidget.alarm.snooze</string>
     <string name="def_app_alarms_autodismiss" translatable="false">30000</string>    <!-- auto-dismiss after 30s -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1261,9 +1261,6 @@
     <string name="configLabel_alarms_brightMode_fadein">Gradually increase brightness</string>
     <string name="configLabel_alarms_brightMode_fadein_summary"><xliff:g id="timePeriod" example="60 seconds">%s</xliff:g></string>
 
-    <string name="configLabel_alarms_brightMode_color">Screen Color</string>   <!-- TODO -->
-    <string name="configLabel_alarms_brightMode_color_summary">%s</string>
-
     <string name="configLabel_alarms_brightMode_colors">Bright Screen Colors</string>   <!-- TODO -->
     <string name="configLabel_alarms_brightMode_colors_summary">%s</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -935,6 +935,20 @@
     <string name="widgetLabel_declination_symbol">δ</string>           <!-- label/suffix -->
     <string name="widgetLabel_distance">Distance</string>           <!-- label -->
 
+    <string name="configLabel_alarms_bg_startColor">Background (Start)</string>               <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_bg_endColor">Background (End)</string>                   <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_soundingPulse_startColor">Pulse (Sounding)</string>      <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_soundingPulse_endColor">Pulse (Sounding)</string>        <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_snoozingPulse_startColor">Pulse (Snoozing)</string>      <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_snoozingPulse_endColor">Pulse (Snoozing)</string>        <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_primaryColor">Primary Text</string>                         <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_primaryColorInverse">Primary Text (Inverse)</string>        <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_secondaryColor">Secondary Text</string>                     <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_secondaryColorInverse">Secondary Text (Inverse)</string>    <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_timeColor">Time Text</string>                               <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_timeColorInverse">Time Text (inverse)</string>              <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_text_disabledColor">Disabled</string>                            <!-- color label -->    <!-- TODO -->
+
     <!--
          CUSTOM EVENTS
     -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1264,6 +1264,9 @@
     <string name="configLabel_alarms_brightMode_color">Screen Color</string>   <!-- TODO -->
     <string name="configLabel_alarms_brightMode_color_summary">%s</string>
 
+    <string name="configLabel_alarms_brightMode_colors">Bright Screen Colors</string>   <!-- TODO -->
+    <string name="configLabel_alarms_brightMode_colors_summary">%s</string>
+
     <string name="configLabel_alarms_nextAlarm">Alarm</string>                             <!-- widget label ("next alarm") -->
     <string name="configLabel_alarms_nextAlarm_none">No alarm set</string>            <!-- widget text (no alarm set msg) -->
     <string name="configLabel_alarms_nextAlarm_error">Failed to load!</string>            <!-- widget text (null/missing error) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1285,6 +1285,10 @@
         <item>color_control_pressed</item>-->
     </string-array>
 
+    <string name="brightMode_colors_label_default">@string/configLabel_tagDefault</string>  <!-- TODO -->
+    <string name="brightMode_colors_label_sunrise">@string/sunrise_short</string>  <!-- TODO -->
+    <string name="brightMode_colors_label_foliage">Foliage</string>  <!-- TODO -->
+
     <string name="configLabel_alarms_nextAlarm">Alarm</string>                             <!-- widget label ("next alarm") -->
     <string name="configLabel_alarms_nextAlarm_none">No alarm set</string>            <!-- widget text (no alarm set msg) -->
     <string name="configLabel_alarms_nextAlarm_error">Failed to load!</string>            <!-- widget text (null/missing error) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -919,7 +919,7 @@
     <string name="configHint_themeID">Theme ID</string>                  <!-- edit hint -->
 
     <string name="configLabel_themeName">Display:</string>               <!-- edit label -->
-    <string name="configHint_themeName">Label</string>                   <!-- edit hint -->
+    <string name="configHint_themeName">@string/hint_label</string>                   <!-- edit hint -->
 
     <string name="widgetLabel_azimuth">Azimuth</string>                   <!-- label -->
     <string name="widgetLabel_azimuth_short">Az</string>                   <!-- label -->
@@ -936,7 +936,7 @@
     <string name="widgetLabel_distance">Distance</string>           <!-- label -->
 
     <string name="configLabel_alarms_bg_startColor">Background (Start)</string>               <!-- color label -->    <!-- TODO -->
-    <string name="configLabel_alarms_bg_endColor">Background (End)</string>                   <!-- color label -->    <!-- TODO -->
+    <string name="configLabel_alarms_bg_endColor">Background (Finish)</string>                <!-- color label -->    <!-- TODO -->
     <string name="configLabel_alarms_soundingPulse_startColor">Pulse (Sounding)</string>      <!-- color label -->    <!-- TODO -->
     <string name="configLabel_alarms_soundingPulse_endColor">Pulse (Sounding)</string>        <!-- color label -->    <!-- TODO -->
     <string name="configLabel_alarms_snoozingPulse_startColor">Pulse (Snoozing)</string>      <!-- color label -->    <!-- TODO -->
@@ -1007,7 +1007,7 @@
 
     <string name="editevent_dialog_title">Event</string>    <!-- 'add event' title -->
     <string name="editevent_dialog_title1">Event</string>    <!-- 'edit event' title -->
-    <string name="editevent_dialog_label_label">Label</string>
+    <string name="editevent_dialog_label_label">@string/hint_label</string>
     <string name="editevent_dialog_label_hint">Event Label</string>
     <string name="editevent_dialog_label_error">@string/addaction_error_title</string>
     <string name="editevent_dialog_label_suggested">Custom Angle</string>
@@ -1153,7 +1153,7 @@
     <string name="alarmlabel_dialog_title">Label</string>        <!-- dialog title -->
     <string name="alarmlabel_dialog_ok">Apply</string>        <!-- button -->
     <string name="alarmlabel_dialog_cancel">Cancel</string>    <!-- button -->
-    <string name="alarmlabel_hint">Label</string>        <!-- EditText hint -->
+    <string name="alarmlabel_hint">@string/hint_label</string>        <!-- EditText hint -->
 
     <string name="alarmnote_dialog_title">Note</string>        <!-- dialog title -->
 
@@ -2537,6 +2537,7 @@
 
     <string name="suggest_colorid">Custom</string>       <!-- edittext hint -->
     <string name="hint_colorid">ID</string>              <!-- edittext hint -->
+    <string name="hint_colorlabel">@string/hint_label</string>        <!-- edittext hint -->   <!-- TODO -->
     <string name="error_colorid_empty">ID required</string>                  <!-- edittext error text -->
     <string name="error_colorid_spaces">ID may not contains spaces</string>   <!-- edittext error text -->
     <string name="msg_colors_saved">Saved %s</string>        <!-- toast -->
@@ -2859,6 +2860,8 @@
     <string name="configLabel_permissionGranted">Permission Granted</string>    <!-- TODO -->
 
     <string name="drag_hint">Drag here</string>
+
+    <string name="hint_label">Label</string>        <!-- edittext hint -->   <!-- TODO -->
 
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1254,6 +1254,9 @@
     <string name="configLabel_alarms_brightMode_fadein">Gradually increase brightness</string>
     <string name="configLabel_alarms_brightMode_fadein_summary"><xliff:g id="timePeriod" example="60 seconds">%s</xliff:g></string>
 
+    <string name="configLabel_alarms_brightMode_color">Screen Color</string>   <!-- TODO -->
+    <string name="configLabel_alarms_brightMode_color_summary">%s</string>
+
     <string name="configLabel_alarms_nextAlarm">Alarm</string>                             <!-- widget label ("next alarm") -->
     <string name="configLabel_alarms_nextAlarm_none">No alarm set</string>            <!-- widget text (no alarm set msg) -->
     <string name="configLabel_alarms_nextAlarm_error">Failed to load!</string>            <!-- widget text (null/missing error) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1419,6 +1419,7 @@
     <string name="restorebackup_dialog_item_colors">Colors</string>
     <string name="restorebackup_dialog_item_colors_appcolors">App Colors</string>
     <string name="restorebackup_dialog_item_colors_mapcolors">Map Colors</string>
+    <string name="restorebackup_dialog_item_colors_alarmcolors">Alarm Colors</string>  <!-- TODO -->
     <string name="restorebackup_dialog_item_widgetsettings">Widget Settings</string>
     <string name="restorebackup_dialog_item_widgetthemes">Widget Themes</string>
     <string name="restorebackup_dialog_item_placeitems">Places</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1275,7 +1275,7 @@
     <string name="configLabel_alarms_brightMode_fadein">Gradually increase brightness</string>
     <string name="configLabel_alarms_brightMode_fadein_summary"><xliff:g id="timePeriod" example="60 seconds">%s</xliff:g></string>
 
-    <string name="configLabel_alarms_brightMode_colors">Bright Screen Colors</string>   <!-- TODO -->
+    <string name="configLabel_alarms_brightMode_colors">Bright Alarm Colors</string>   <!-- TODO -->
     <string name="configLabel_alarms_brightMode_colors_summary">%s</string>
     <string-array name="brightMode_colors_previewKeys" translatable="false">
         <item>color_bright_bg_end</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1279,10 +1279,10 @@
     <string name="configLabel_alarms_brightMode_colors_summary">%s</string>
     <string-array name="brightMode_colors_previewKeys" translatable="false">
         <item>color_bright_bg_end</item>
-        <item>color_sounding_pulse_start</item>
+        <!--<item>color_sounding_pulse_start</item>
         <item>color_sounding_pulse_end</item>
         <item>color_control_enabled</item>
-        <item>color_control_pressed</item>
+        <item>color_control_pressed</item>-->
     </string-array>
 
     <string name="configLabel_alarms_nextAlarm">Alarm</string>                             <!-- widget label ("next alarm") -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1288,6 +1288,7 @@
     <string name="brightMode_colors_label_default">@string/configLabel_tagDefault</string>  <!-- TODO -->
     <string name="brightMode_colors_label_sunrise">@string/sunrise_short</string>  <!-- TODO -->
     <string name="brightMode_colors_label_foliage">Foliage</string>  <!-- TODO -->
+    <string name="brightMode_colors_label_bluesky">Blue Sky</string>  <!-- TODO -->
 
     <string name="configLabel_alarms_nextAlarm">Alarm</string>                             <!-- widget label ("next alarm") -->
     <string name="configLabel_alarms_nextAlarm_none">No alarm set</string>            <!-- widget text (no alarm set msg) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2538,6 +2538,7 @@
     <string name="suggest_colorid">Custom</string>       <!-- edittext hint -->
     <string name="hint_colorid">ID</string>              <!-- edittext hint -->
     <string name="hint_colorlabel">@string/hint_label</string>        <!-- edittext hint -->   <!-- TODO -->
+    <string name="error_colorlabel_empty">Label required</string>           <!-- edittext error text -->   <!-- TODO -->
     <string name="error_colorid_empty">ID required</string>                  <!-- edittext error text -->
     <string name="error_colorid_spaces">ID may not contains spaces</string>   <!-- edittext error text -->
     <string name="msg_colors_saved">Saved %s</string>        <!-- toast -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1263,6 +1263,13 @@
 
     <string name="configLabel_alarms_brightMode_colors">Bright Screen Colors</string>   <!-- TODO -->
     <string name="configLabel_alarms_brightMode_colors_summary">%s</string>
+    <string-array name="brightMode_colors_previewKeys" translatable="false">
+        <item>color_bright_bg_end</item>
+        <item>color_sounding_pulse_start</item>
+        <item>color_sounding_pulse_end</item>
+        <item>color_control_enabled</item>
+        <item>color_control_pressed</item>
+    </string-array>
 
     <string name="configLabel_alarms_nextAlarm">Alarm</string>                             <!-- widget label ("next alarm") -->
     <string name="configLabel_alarms_nextAlarm_none">No alarm set</string>            <!-- widget text (no alarm set msg) -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1173,6 +1173,10 @@
         <item name="android:padding">3dp</item>
         <item name="android:layout_margin">0dp</item>
     </style>
+    <style name="ColorEditButton3" parent="ColorEditButton2">
+        <item name="android:layout_width">48dp</item>
+        <item name="android:layout_height">48dp</item>
+    </style>
 
     <style name="SizeEdit" parent="@style/TextAppearance.AppCompat.Small">
         <item name="android:layout_width">50dp</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1325,6 +1325,9 @@
     <style name="DialogTitleStyle" parent="TableHeadTextView0">        <!-- rise/set header text -->
         <item name="android:textSize">?attr/text_size_large</item>
     </style>
+    <style name="DialogSubTitleStyle">
+        <item name="android:textSize">?attr/text_size_small</item>
+    </style>
 
     <style name="EquinoxDialogTitleStyle" parent="TableHeadDateView">
         <item name="android:textSize">?attr/text_size_large</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
         <item name="hrColor">@color/hr</item>
         <item name="colorAccent">@color/text_accent</item>
         <item name="text_primaryColor">@color/text_primary</item>
+        <item name="text_primaryInverseColor">@color/text_primary_inverse</item>
         <item name="text_secondaryColor">@color/text_secondary</item>
         <item name="text_tertiaryColor">@color/text_tertiary</item>
         <item name="text_accentColor">@color/text_accent</item>
@@ -254,6 +255,7 @@
         <item name="hrColor">@color/hr_light</item>
         <item name="colorAccent">@color/text_accent_light</item>
         <item name="text_primaryColor">@color/text_primary_light</item>
+        <item name="text_primaryInverseColor">@color/text_primary_inverse_light</item>
         <item name="text_secondaryColor">@color/text_secondary_light</item>
         <item name="text_tertiaryColor">@color/text_tertiary_light</item>
         <item name="text_accentColor">@color/text_accent_light</item>
@@ -491,6 +493,7 @@
         <item name="hrColor">@color/hr_dark</item>
         <item name="colorAccent">@color/text_accent_dark</item>
         <item name="text_primaryColor">@color/text_primary_dark</item>
+        <item name="text_primaryInverseColor">@color/text_primary_inverse_dark</item>
         <item name="text_secondaryColor">@color/text_secondary_dark</item>
         <item name="text_tertiaryColor">@color/text_tertiary_dark</item>
         <item name="text_accentColor">@color/text_accent_dark</item>

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -100,7 +100,7 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
-        <com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference
+        <com.forrestguice.suntimeswidget.colors.ColorValuesCollectionPreference
             android:key="app_alarms_bright_colors"
             android:persistent="false"
             app:colorTag="alarmcolors" app:appWidgetID="0" app:showAlpha="true"

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -113,6 +113,7 @@
             android:title="@string/configLabel_alarms_brightMode_color"
             android:summary="@string/configLabel_alarms_brightMode_color_summary"
             app:colorValues="@array/alarm_bright_colors_list"
+            android:numColumns="3"
             android:widgetLayout="@layout/layout_pref_color"
             android:defaultValue="@color/def_app_alarms_bright_color_end" />
 

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -117,6 +117,12 @@
             android:widgetLayout="@layout/layout_pref_color"
             android:defaultValue="@color/def_app_alarms_bright_color_end" />
 
+        <Preference
+            android:key="app_alarms_bright_colors"
+            android:persistent="false"
+            android:title="@string/configLabel_alarms_brightMode_colors"
+            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -100,9 +100,11 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
-        <Preference
+        <com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference
             android:key="app_alarms_bright_colors"
             android:persistent="false"
+            app:colorTag="alarmcolors" app:appWidgetID="0" app:showAlpha="true"
+            android:widgetLayout="@layout/layout_pref_colors" app:previewKeys="@array/brightMode_colors_previewKeys"
             android:title="@string/configLabel_alarms_brightMode_colors"
             android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
 

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -112,6 +112,14 @@
             app:maxValue="@integer/maxAlarmFullscreenFadeinSeconds"
             android:defaultValue="@string/def_app_alarms_bright_fadein" />
 
+        <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
+            android:key="app_alarms_bright_color_end"
+            android:title="@string/configLabel_alarms_brightMode_color"
+            android:summary="@string/configLabel_alarms_brightMode_color_summary"
+            app:colorValues="@array/alarm_bright_colors_list"
+            android:widgetLayout="@layout/layout_pref_color"
+            android:defaultValue="@color/def_app_alarms_bright_color_end" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v11/preference_alarms.xml
+++ b/app/src/main/res/xml-v11/preference_alarms.xml
@@ -100,6 +100,12 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
+        <Preference
+            android:key="app_alarms_bright_colors"
+            android:persistent="false"
+            android:title="@string/configLabel_alarms_brightMode_colors"
+            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+
         <com.forrestguice.suntimeswidget.settings.MillisecondPickerPreference
             android:key="app_alarms_bright_fadeinMillis"
             android:title="@string/configLabel_alarms_brightMode_fadein"
@@ -108,20 +114,14 @@
             app:maxValue="@integer/maxAlarmFullscreenFadeinSeconds"
             android:defaultValue="@string/def_app_alarms_bright_fadein" />
 
-        <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
+        <!--<com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
             android:key="app_alarms_bright_color_end"
             android:title="@string/configLabel_alarms_brightMode_color"
             android:summary="@string/configLabel_alarms_brightMode_color_summary"
             app:colorValues="@array/alarm_bright_colors_list"
             android:numColumns="3"
             android:widgetLayout="@layout/layout_pref_color"
-            android:defaultValue="@color/def_app_alarms_bright_color_end" />
-
-        <Preference
-            android:key="app_alarms_bright_colors"
-            android:persistent="false"
-            android:title="@string/configLabel_alarms_brightMode_colors"
-            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+            android:defaultValue="@color/def_app_alarms_bright_color_end" />-->
 
     </PreferenceCategory>
 

--- a/app/src/main/res/xml-v34/preference_alarms.xml
+++ b/app/src/main/res/xml-v34/preference_alarms.xml
@@ -102,6 +102,14 @@
             app:maxValue="@integer/maxAlarmFullscreenFadeinSeconds"
             android:defaultValue="@string/def_app_alarms_bright_fadein" />
 
+        <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
+            android:key="app_alarms_bright_color_end"
+            android:title="@string/configLabel_alarms_brightMode_color"
+            android:summary="@string/configLabel_alarms_brightMode_color_summary"
+            app:colorValues="@array/alarm_bright_colors_list"
+            android:widgetLayout="@layout/layout_pref_color"
+            android:defaultValue="@color/def_app_alarms_bright_color_end" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v34/preference_alarms.xml
+++ b/app/src/main/res/xml-v34/preference_alarms.xml
@@ -105,7 +105,7 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
-        <com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference
+        <com.forrestguice.suntimeswidget.colors.ColorValuesCollectionPreference
             android:key="app_alarms_bright_colors"
             android:persistent="false"
             app:colorTag="alarmcolors" app:appWidgetID="0" app:showAlpha="true"

--- a/app/src/main/res/xml-v34/preference_alarms.xml
+++ b/app/src/main/res/xml-v34/preference_alarms.xml
@@ -105,9 +105,11 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
-        <Preference
+        <com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference
             android:key="app_alarms_bright_colors"
             android:persistent="false"
+            app:colorTag="alarmcolors" app:appWidgetID="0" app:showAlpha="true"
+            android:widgetLayout="@layout/layout_pref_colors" app:previewKeys="@array/brightMode_colors_previewKeys"
             android:title="@string/configLabel_alarms_brightMode_colors"
             android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
 

--- a/app/src/main/res/xml-v34/preference_alarms.xml
+++ b/app/src/main/res/xml-v34/preference_alarms.xml
@@ -105,6 +105,12 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
+        <Preference
+            android:key="app_alarms_bright_colors"
+            android:persistent="false"
+            android:title="@string/configLabel_alarms_brightMode_colors"
+            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+
         <com.forrestguice.suntimeswidget.settings.MillisecondPickerPreference
             android:key="app_alarms_bright_fadeinMillis"
             android:title="@string/configLabel_alarms_brightMode_fadein"
@@ -113,20 +119,14 @@
             app:maxValue="@integer/maxAlarmFullscreenFadeinSeconds"
             android:defaultValue="@string/def_app_alarms_bright_fadein" />
 
-        <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
+        <!-- <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
             android:key="app_alarms_bright_color_end"
             android:title="@string/configLabel_alarms_brightMode_color"
             android:summary="@string/configLabel_alarms_brightMode_color_summary"
             android:numColumns="3"
             app:colorValues="@array/alarm_bright_colors_list"
             android:widgetLayout="@layout/layout_pref_color"
-            android:defaultValue="@color/def_app_alarms_bright_color_end" />
-
-        <Preference
-            android:key="app_alarms_bright_colors"
-            android:persistent="false"
-            android:title="@string/configLabel_alarms_brightMode_colors"
-            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+            android:defaultValue="@color/def_app_alarms_bright_color_end" />-->
 
     </PreferenceCategory>
 

--- a/app/src/main/res/xml-v34/preference_alarms.xml
+++ b/app/src/main/res/xml-v34/preference_alarms.xml
@@ -117,6 +117,7 @@
             android:key="app_alarms_bright_color_end"
             android:title="@string/configLabel_alarms_brightMode_color"
             android:summary="@string/configLabel_alarms_brightMode_color_summary"
+            android:numColumns="3"
             app:colorValues="@array/alarm_bright_colors_list"
             android:widgetLayout="@layout/layout_pref_color"
             android:defaultValue="@color/def_app_alarms_bright_color_end" />

--- a/app/src/main/res/xml-v34/preference_alarms.xml
+++ b/app/src/main/res/xml-v34/preference_alarms.xml
@@ -122,6 +122,12 @@
             android:widgetLayout="@layout/layout_pref_color"
             android:defaultValue="@color/def_app_alarms_bright_color_end" />
 
+        <Preference
+            android:key="app_alarms_bright_colors"
+            android:persistent="false"
+            android:title="@string/configLabel_alarms_brightMode_colors"
+            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -113,6 +113,12 @@
             android:widgetLayout="@layout/layout_pref_color"
             android:defaultValue="@color/def_app_alarms_bright_color_end" />
 
+        <Preference
+            android:key="app_alarms_bright_colors"
+            android:persistent="false"
+            android:title="@string/configLabel_alarms_brightMode_colors"
+            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -96,6 +96,12 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
+        <Preference
+            android:key="app_alarms_bright_colors"
+            android:persistent="false"
+            android:title="@string/configLabel_alarms_brightMode_colors"
+            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+
         <com.forrestguice.suntimeswidget.settings.MillisecondPickerPreference
             android:key="app_alarms_bright_fadeinMillis"
             android:title="@string/configLabel_alarms_brightMode_fadein"
@@ -104,20 +110,14 @@
             app:maxValue="@integer/maxAlarmFullscreenFadeinSeconds"
             android:defaultValue="@string/def_app_alarms_bright_fadein" />
 
-        <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
+        <!--<com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
             android:key="app_alarms_bright_color_end"
             android:title="@string/configLabel_alarms_brightMode_color"
             android:summary="@string/configLabel_alarms_brightMode_color_summary"
             android:numColumns="3"
             app:colorValues="@array/alarm_bright_colors_list"
             android:widgetLayout="@layout/layout_pref_color"
-            android:defaultValue="@color/def_app_alarms_bright_color_end" />
-
-        <Preference
-            android:key="app_alarms_bright_colors"
-            android:persistent="false"
-            android:title="@string/configLabel_alarms_brightMode_colors"
-            android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
+            android:defaultValue="@color/def_app_alarms_bright_color_end" />-->
 
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -108,6 +108,7 @@
             android:key="app_alarms_bright_color_end"
             android:title="@string/configLabel_alarms_brightMode_color"
             android:summary="@string/configLabel_alarms_brightMode_color_summary"
+            android:numColumns="3"
             app:colorValues="@array/alarm_bright_colors_list"
             android:widgetLayout="@layout/layout_pref_color"
             android:defaultValue="@color/def_app_alarms_bright_color_end" />

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -94,6 +94,14 @@
             app:maxValue="@integer/maxAlarmFullscreenFadeinSeconds"
             android:defaultValue="@string/def_app_alarms_bright_fadein" />
 
+        <com.forrestguice.suntimeswidget.settings.colors.ColorListPreference
+            android:key="app_alarms_bright_color_end"
+            android:title="@string/configLabel_alarms_brightMode_color"
+            android:summary="@string/configLabel_alarms_brightMode_color_summary"
+            app:colorValues="@array/alarm_bright_colors_list"
+            android:widgetLayout="@layout/layout_pref_color"
+            android:defaultValue="@color/def_app_alarms_bright_color_end" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -96,9 +96,11 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
-        <Preference
+        <com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference
             android:key="app_alarms_bright_colors"
             android:persistent="false"
+            app:colorTag="alarmcolors" app:appWidgetID="0" app:showAlpha="true"
+            android:widgetLayout="@layout/layout_pref_colors" app:previewKeys="@array/brightMode_colors_previewKeys"
             android:title="@string/configLabel_alarms_brightMode_colors"
             android:summary="@string/configLabel_alarms_brightMode_colors_summary" />
 

--- a/app/src/main/res/xml/preference_alarms.xml
+++ b/app/src/main/res/xml/preference_alarms.xml
@@ -96,7 +96,7 @@
             android:summary="@string/configLabel_alarms_brightMode_summary"
             android:defaultValue="@bool/def_app_alarms_bright" />
 
-        <com.forrestguice.suntimeswidget.settings.colors.ColorCollectionPreference
+        <com.forrestguice.suntimeswidget.colors.ColorValuesCollectionPreference
             android:key="app_alarms_bright_colors"
             android:persistent="false"
             app:colorTag="alarmcolors" app:appWidgetID="0" app:showAlpha="true"

--- a/app/src/main/res/xml/preference_userinterface.xml
+++ b/app/src/main/res/xml/preference_userinterface.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
         android:title="@string/configLabel_appearance">
@@ -17,14 +18,16 @@
             android:title="@string/appThemes_lightTheme"
             android:dialogTitle="@string/appThemes_lightTheme"
             android:widgetLayout="@layout/layout_pref_themewidget"
-            android:summary="%s" />
+            android:summary="%s"
+            app:actionButtonContentDescription="@string/configActionDesc_themeList" />
 
         <com.forrestguice.suntimeswidget.settings.ActionButtonPreference
             android:key="app_appearance_theme_dark"
             android:title="@string/appThemes_darkTheme"
             android:dialogTitle="@string/appThemes_darkTheme"
             android:widgetLayout="@layout/layout_pref_themewidget"
-            android:summary="%s" />
+            android:summary="%s"
+            app:actionButtonContentDescription="@string/configActionDesc_themeList" />
 
         <com.forrestguice.suntimeswidget.settings.TextSizePreference
             android:key="app_appearance_textsize"
@@ -246,7 +249,7 @@
             android:summary="%s" android:widgetLayout="@layout/layout_pref_action"
             android:entries="@array/clockTapActions_display" android:entryValues="@array/clockTapActions_values"
             android:defaultValue="@string/def_app_ui_clocktapaction"
-            />
+            app:actionButtonContentDescription="@string/configActionDesc_actionList" />
 
         <com.forrestguice.suntimeswidget.settings.ActionButtonPreference
             android:key="app_ui_datetapaction"
@@ -254,7 +257,8 @@
             android:dialogTitle="@string/configLabel_action_onDateTap"
             android:summary="%s" android:widgetLayout="@layout/layout_pref_action"
             android:entries="@array/dateTapActions_display" android:entryValues="@array/dateTapActions_values"
-            android:defaultValue="@string/def_app_ui_datetapaction" />
+            android:defaultValue="@string/def_app_ui_datetapaction"
+            app:actionButtonContentDescription="@string/configActionDesc_actionList" />
 
         <com.forrestguice.suntimeswidget.settings.ActionButtonPreference
             android:key="app_ui_datetapaction1"
@@ -262,7 +266,8 @@
             android:dialogTitle="@string/configLabel_action_onDateTap1"
             android:summary="%s" android:widgetLayout="@layout/layout_pref_action"
             android:entries="@array/dateTapActions_display" android:entryValues="@array/dateTapActions_values"
-            android:defaultValue="@string/def_app_ui_datetapaction1" />
+            android:defaultValue="@string/def_app_ui_datetapaction1"
+            app:actionButtonContentDescription="@string/configActionDesc_actionList" />
 
         <com.forrestguice.suntimeswidget.settings.ActionButtonPreference
             android:key="app_ui_notetapaction"
@@ -270,7 +275,8 @@
             android:dialogTitle="@string/configLabel_action_onNoteTap"
             android:summary="%s" android:widgetLayout="@layout/layout_pref_action"
             android:entries="@array/noteTapActions_display" android:entryValues="@array/noteTapActions_values"
-            android:defaultValue="@string/def_app_ui_notetapaction" />
+            android:defaultValue="@string/def_app_ui_notetapaction"
+            app:actionButtonContentDescription="@string/configActionDesc_actionList" />
 
     </PreferenceCategory>
 

--- a/app/src/test/java/com/forrestguice/suntimeswidget/settings/AppSettingsTest0.java
+++ b/app/src/test/java/com/forrestguice/suntimeswidget/settings/AppSettingsTest0.java
@@ -19,6 +19,7 @@
 package com.forrestguice.suntimeswidget.settings;
 
 import com.forrestguice.suntimeswidget.alarmclock.AlarmSettings;
+import com.forrestguice.suntimeswidget.alarmclock.ui.colors.BrightAlarmColorValuesCollection;
 import com.forrestguice.suntimeswidget.calendar.CalendarSettings;
 import com.forrestguice.suntimeswidget.colors.AppColorValuesCollection;
 import com.forrestguice.suntimeswidget.map.WorldMapWidgetSettings;
@@ -58,6 +59,7 @@ public class AppSettingsTest0
     {
         test_prefTypeInfo("AppColors", AppColorValuesCollection.getPrefTypeInfo(), AppColorValuesCollection.getPrefTypes());
         test_prefTypeInfo("MapColors", WorldMapColorValuesCollection.getPrefTypeInfo(), WorldMapColorValuesCollection.getPrefTypes());
+        test_prefTypeInfo("AlarmColors", BrightAlarmColorValuesCollection.getPrefTypeInfo(), BrightAlarmColorValuesCollection.getPrefTypes());
         test_prefTypeInfo("AppSettings", AppSettings.getPrefTypeInfo(), AppSettings.getPrefTypes());
         test_prefTypeInfo("AlarmSettings", AlarmSettings.getPrefTypeInfo(), AlarmSettings.getPrefTypes());
         test_prefTypeInfo("CalendarSettings", CalendarSettings.getPrefTypeInfo(), CalendarSettings.getPrefTypes());


### PR DESCRIPTION
* fixes "bright alarms" text readability issues.
* adds "bright alarm colors" to alarm settings; allows customization of fullscreen alarm colors (#741).
* adds "color list preference"; select preference color from a pre-defined list of colors.
* adds a separate activity for picking or modifying custom colors.
* fixes bug where color dialog fails to show the alpha slider.
* fixes misaligned click area in the "action button preference".
* fixes bug where welcome activity is cropped on smaller screens or landscape orientation.