### PR TITLE
release 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.16.2 (2024-09-20)
+### v0.16.2 (2024-09-23)
 * adds "bright alarm colors"; allows customization of fullscreen alarm colors (#741).
 * adds "do-not-disturb" preference that indicates the state of the required permission (#818).
 * adds "app restricted" warning; "Alarms may fail to work reliably" when the app is in the rare or restricted app-standby-bucket.
@@ -8,15 +8,17 @@
 * fixes missing "bright alarm" setting on Android 14 (#741).
 * fixes bug where bedtime do-not-disturb fails to activate (#818).
 * fixes bug where bedtime notifications are hidden due to low priority (adds a separate bedtime notification channel).
+* fixes bug where the alarm foreground service fails to stop after triggering notifications.
 * fixes missing notification text when the alarm foreground service does periodic work.
 * fixes text contrast/readability issues when modifying custom colors (support for "color roles").
 * enhances custom colors to allow for user-defined labels.
 * fixes bug where color dialog fails to show the alpha slider, and other miscellaneous improvements.
-* fixes misaligned click area in the "action button preference", and other miscellaneous changes.
+* fixes bug where the "tap action" preference click area is misaligned.
 * fixes bug where welcome activity is cropped in landscape orientation (Android TV).
-* fixes "back" action to dismiss visible warnings first (Android TV).
-* fixes inaccurate place coordinates; Bangui, Conakry.
+* fixes the "back" gesture so that it dismisses visible warnings first (Android TV).
+* fixes inaccurate default place coordinates; Bangui, Conakry.
 * updates build; removes jcenter; updates `com.jraska:falcon` to `2.2.0` (#825).
+* updates translation to Norwegian (nb) (#832 by FTno).
 
 ### v0.16.1 (2024-08-19)
 * adds "material palette" to the color dialog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ### ~
 
+### v0.16.2 (2024-09-20)
+* adds "bright alarm colors"; allows customization of fullscreen alarm colors (#741).
+* adds "do-not-disturb" preference that indicates the state of the required permission (#818).
+* adds "app restricted" warning; "Alarms may fail to work reliably" when the app is in the rare or restricted app-standby-bucket.
+* fixes crash in sunlight widget (#735).
+* fixes missing "bright alarm" setting on Android 14 (#741).
+* fixes bug where bedtime do-not-disturb fails to activate (#818).
+* fixes bug where bedtime notifications are hidden due to low priority (adds a separate bedtime notification channel).
+* fixes missing notification text when the alarm foreground service does periodic work.
+* fixes text contrast/readability issues when modifying custom colors (support for "color roles").
+* enhances custom colors to allow for user-defined labels.
+* fixes bug where color dialog fails to show the alpha slider, and other miscellaneous improvements.
+* fixes misaligned click area in the "action button preference", and other miscellaneous changes.
+* fixes bug where welcome activity is cropped in landscape orientation (Android TV).
+* fixes "back" action to dismiss visible warnings first (Android TV).
+* fixes inaccurate place coordinates; Bangui, Conakry.
+* updates build; removes jcenter; updates `com.jraska:falcon` to `2.2.0` (#825).
+
 ### v0.16.1 (2024-08-19)
 * adds "material palette" to the color dialog.
 * adds text color preview, and other miscellaneous color picker improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * fixes inaccurate default place coordinates; Bangui, Conakry.
 * updates build; removes jcenter; updates `com.jraska:falcon` to `2.2.0` (#825).
 * updates translation to Norwegian (nb) (#832 by FTno).
+* updates translation to Polish and Esperanto (eo, pl) (#833 by Verdulo).
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#836 by James Liu).
 
 ### v0.16.1 (2024-08-19)
 * adds "material palette" to the color dialog.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 115
-        versionName "0.16.1"
+        versionCode 116
+        versionName "0.16.2"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/116.txt
+++ b/fastlane/metadata/android/en-US/changelogs/116.txt
@@ -4,3 +4,5 @@
 - fixes text readability when modifying custom colors.
 - adds "bright alarm colors" (customize the alarm screen).
 - updates translation to Norwegian.
+- updates translation to Polish and Esperanto.
+- updates translations to Simplified Chinese, and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/116.txt
+++ b/fastlane/metadata/android/en-US/changelogs/116.txt
@@ -1,0 +1,5 @@
+- fixes crash in sunlight widget (#735).
+- fixes bugs when triggering bedtime mode (#818).
+- fixes missing "bright alarm" setting (Android 14).
+- fixes text readability when modifying custom colors.
+- adds "bright alarm colors" (customize the alarm screen).

--- a/fastlane/metadata/android/en-US/changelogs/116.txt
+++ b/fastlane/metadata/android/en-US/changelogs/116.txt
@@ -3,3 +3,4 @@
 - fixes missing "bright alarm" setting (Android 14).
 - fixes text readability when modifying custom colors.
 - adds "bright alarm colors" (customize the alarm screen).
+- updates translation to Norwegian.


### PR DESCRIPTION
* adds "bright alarm colors"; allows customization of fullscreen alarm colors (#741).
* adds "do-not-disturb" preference that indicates the state of the required permission (#818).
* adds "app restricted" warning; "Alarms may fail to work reliably" when the app is in the rare or restricted app-standby-bucket.
* fixes crash in sunlight widget (#735).
* fixes missing "bright alarm" setting (Android 14) (#741).
* fixes bug where bedtime do-not-disturb fails to activate (#818).
* fixes bug where bedtime notifications are hidden due to low priority (adds a separate bedtime notification channel).
* fixes bug where the alarm foreground service fails to stop after triggering notifications.
* fixes missing notification text when the alarm foreground service does periodic work.
* fixes text contrast/readability issues when modifying custom colors (support for "color roles").
* enhances custom colors to allow for user-defined labels.
* fixes bug where color dialog fails to show the alpha slider, and other miscellaneous improvements.
* fixes bug where the "tap action" preference click area is misaligned.
* fixes bug where welcome activity is cropped in landscape orientation (Android TV).
* fixes the "back" gesture so that it dismisses visible warnings first (Android TV).
* fixes inaccurate default place coordinates; Bangui, Conakry.
* updates build; removes jcenter; updates `com.jraska:falcon` to `2.2.0` (#825).
* updates translation to Norwegian (nb) (#832 by FTno). #674
* updates translation to Polish and Esperanto (eo, pl) (#833 by Verdulo).  #662 #663
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#836 by James Liu). #680 #681