### PR TITLE
boot completed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -375,6 +375,10 @@
                 android:value="com.forrestguice.suntimeswidget/com.forrestguice.suntimeswidget.alarmclock.ui.bedtime.BedtimeActivity" />
         </service>
 
+        <service android:name=".alarmclock.AlarmJobService"
+            android:enabled="@bool/api_post_24"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
         <service android:name=".alarmclock.AlarmNotifications$NotificationService"
             android:directBootAware="true" />
         <receiver android:name=".alarmclock.AlarmNotifications"

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmJobService.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmJobService.java
@@ -1,0 +1,89 @@
+/**
+    Copyright (C) 2024 Forrest Guice
+    This file is part of SuntimesWidget.
+
+    SuntimesWidget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SuntimesWidget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SuntimesWidget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.forrestguice.suntimeswidget.alarmclock;
+
+import android.annotation.TargetApi;
+import android.app.job.JobInfo;
+import android.app.job.JobParameters;
+import android.app.job.JobScheduler;
+import android.app.job.JobService;
+import android.content.ComponentName;
+import android.content.Context;
+import android.util.Log;
+
+@TargetApi(24)
+public class AlarmJobService extends JobService
+{
+    public static final String TAG = "AlarmJobService";
+    public static final int JOB_AFTER_BOOT_COMPLETED = 10;
+
+    /**
+     * @param params job params
+     * @return true if job is still ongoing, false if job is finished (releases wakelock)
+     */
+    @Override
+    public boolean onStartJob(JobParameters params)
+    {
+        Log.d(TAG, "onJobStart: " + params.getJobId());
+        switch (params.getJobId())
+        {
+            case JOB_AFTER_BOOT_COMPLETED:
+                return onJobAfterBootCompleted();
+
+            default:
+                Log.w(TAG, "onJobStart: jobId " + params.getJobId() + " not recognized!");
+                return false;    // false; job is finished
+        }
+    }
+
+    /**
+     * onStopJob runs if job is stopped before successful completion
+     * @param params params
+     * @return true if job should be retried
+     */
+    @Override
+    public boolean onStopJob(JobParameters params)
+    {
+        Log.w(TAG, "onJobStop: " + params.getJobId());
+        return false;   // false; no retry
+    }
+
+    protected boolean onJobAfterBootCompleted()
+    {
+        Context context = getApplicationContext();
+        sendBroadcast(AlarmNotifications.getAlarmIntent(context, AlarmNotifications.ACTION_AFTER_BOOT_COMPLETED, null));
+        return false;
+    }
+
+    private static final long AFTER_BOOT_COMPLETED_DELAY_MS = 5 * 1000;    // wait this long before running
+    private static final long AFTER_BOOT_COMPLETED_WINDOW_MS = 25 * 1000;    // job to be run between [delay, delay + window]
+
+    public static void scheduleJobAfterBootCompleted(Context context)
+    {
+        JobInfo.Builder job = new JobInfo.Builder(AlarmJobService.JOB_AFTER_BOOT_COMPLETED, new ComponentName(context, AlarmJobService.class))
+                .setRequiresBatteryNotLow(false).setRequiresCharging(false).setRequiresDeviceIdle(false).setRequiresStorageNotLow(false)  // defaults
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_NONE).setRequiredNetwork(null)
+                .setMinimumLatency(AFTER_BOOT_COMPLETED_DELAY_MS)
+                .setOverrideDeadline(AFTER_BOOT_COMPLETED_DELAY_MS + AFTER_BOOT_COMPLETED_WINDOW_MS);
+
+        JobScheduler jobs = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        jobs.schedule(job.build());
+    }
+
+}

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmJobService.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmJobService.java
@@ -77,8 +77,7 @@ public class AlarmJobService extends JobService
     public static void scheduleJobAfterBootCompleted(Context context)
     {
         JobInfo.Builder job = new JobInfo.Builder(AlarmJobService.JOB_AFTER_BOOT_COMPLETED, new ComponentName(context, AlarmJobService.class))
-                .setRequiresBatteryNotLow(false).setRequiresCharging(false).setRequiresDeviceIdle(false).setRequiresStorageNotLow(false)  // defaults
-                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_NONE).setRequiredNetwork(null)
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_NONE)
                 .setMinimumLatency(AFTER_BOOT_COMPLETED_DELAY_MS)
                 .setOverrideDeadline(AFTER_BOOT_COMPLETED_DELAY_MS + AFTER_BOOT_COMPLETED_WINDOW_MS);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/alarmclock/AlarmNotifications.java
@@ -1892,7 +1892,7 @@ public class AlarmNotifications extends BroadcastReceiver
                                             notifications.showNotification(context, createAutostartWarningNotification(context), NOTIFICATION_AUTOSTART_WARNING_ID);
                                         }
                                     }
-                                    notifications.dismissNotification(context, NOTIFICATION_SCHEDULE_ALL_ID);
+                                    //notifications.dismissNotification(context, NOTIFICATION_SCHEDULE_ALL_ID);
                                     notifications.stopSelf(startId);
                                 }
                             }, (ids.length > 0 ? NOTIFICATION_SCHEDULE_ALL_DURATION : 0));
@@ -1920,7 +1920,7 @@ public class AlarmNotifications extends BroadcastReceiver
                     }
                 }
             });
-            notifications.startForeground(NOTIFICATION_SCHEDULE_ALL_ID, createProgressNotification(getApplicationContext(), getString(R.string.app_name_alarmclock), getString(R.string.configLabel_alarms_bootcompleted_action_message)));
+            //notifications.startForeground(NOTIFICATION_SCHEDULE_ALL_ID, createProgressNotification(getApplicationContext(), getString(R.string.app_name_alarmclock), getString(R.string.configLabel_alarms_bootcompleted_action_message)));
             alarmListTask.execute();
         }
 


### PR DESCRIPTION
* fixes bug "FGS not allowed to start from BOOT_COMPLETED!" (Android 15).
* adds action `AFTER_BOOT_COMPLETED`; changes `ACTION_BOOT_COMPLETED` so that it defers scheduling alarms until a moment later (https://github.com/forrestguice/SuntimesWidget/issues/842)
* removes duplicate progress notification when re-scheduling alarms.