### PR TITLE
release 0.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### ~
 
+### v0.16.4 (2024-12-02)
+* fixes bug "boot completed hangs after phone restart" (#842).
+* fixes bug "FGS not allowed to start from BOOT_COMPLETED!" (Android 15).
+* fixes bug where "moon dialog displays the wrong phase label" (#843).
+* fixes bug where custom color labels are invisible when ellipsized (missing text).
+* fixes bug where text is cropped in moon day widget (#845).
+* fixes bugs in widget previews; missing padding, missing map foreground.
+* adds "preview" action to the "bright alarm colors" selector.
+* adds `AFTER_BOOT_COMPLETED`; changes `ACTION_BOOT_COMPLETED` so that it defers scheduling alarms until a few moments later (#842).
+* adds time-out when querying various content providers to avoid potential ANRs if a provider fails to respond.
+* updates build; replaces jitpack.io artifacts, adds git submodule.
+* updates translation to Polish and Esperanto (eo, pl) (#841 by Verdulo).
+
 ### v0.16.3 (2024-11-04)
 * enhances the quick settings tiles to support displaying their dialogs over the lock screen.
 * improves the appearance of the quick settings tile dialogs (replaces AlertDialog).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.16.4 (2024-12-02)
+### v0.16.4 (2024-12-04)
 * fixes bug "boot completed hangs after phone restart" (#842).
 * fixes bug "FGS not allowed to start from BOOT_COMPLETED!" (Android 15).
 * fixes bug where "moon dialog displays the wrong phase label" (#843).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 117
-        versionName "0.16.3"
+        versionCode 118
+        versionName "0.16.4"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/118.txt
+++ b/fastlane/metadata/android/en-US/changelogs/118.txt
@@ -1,0 +1,5 @@
+- adds "preview" action to the "bright alarm colors" selector.
+- fixes bug "boot completed hangs after phone restart" (#842).
+- fixes bug "FGS not allowed to start from BOOT_COMPLETED!" (Android 15).
+- fixes bug where "moon dialog displays the wrong phase label" (#843).
+- updates translation to Polish and Esperanto.


### PR DESCRIPTION
* fixes bug "boot completed hangs after phone restart" (closes #842).
* fixes bug "FGS not allowed to start from BOOT_COMPLETED!" (Android 15).
* fixes bug where "moon dialog displays the wrong phase label" (closes #843).
* fixes bug where custom color labels are invisible when ellipsized (missing text).
* fixes bug where text is cropped in moon day widget (closes #845).
* fixes bugs in widget previews; missing padding, missing map foreground.
* adds "preview" action to the "bright alarm colors" selector.
* adds `AFTER_BOOT_COMPLETED`; changes `ACTION_BOOT_COMPLETED` so that it defers scheduling alarms until a few moments later (#842, #853).
* adds time-out when querying various content providers to avoid potential ANRs if a provider fails to respond (#852).
* updates build; replaces jitpack.io artifacts, adds git submodule (75041f04feb0cec1effd7c41a79acdd0136ea98c).
* updates translation to Polish and Esperanto (eo, pl) (#841 by Verdulo).