### PR TITLE
release 0.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ### v0.16.6 (2025-04-14)
 * adds option for "solar midnight" (#835).
 * adds world places: ~100 places; US state capitols, major US cities, and others.
-* increases maximum "auto-dismiss after" notification value from 5 minutes to 12 hours (#726).
-* improves UI when configuring time offsets for custom events, alarm, and bedtime settings.
+* adds an indicator to sun dialog when the displayed time is adjusted by DST.
 * fixes bug where "sun position grid does not re-align when DST changes" (#867).
+* fixes bug where "sun position graph labels are always displayed using 12h time".
+* improves UI when configuring time offsets for custom events, alarm, and bedtime settings.
+* increases maximum "auto-dismiss after" notification value from 5 minutes to 12 hours (#726).
 * enhances `%e` data patterns to work with all widget types (no longer limited to sun widgets).
 * adds data patterns: `%es`, `%eS`, `%h`, and `%H`; shadow length, and observer height.
 * adds data patterns: `%ea`, `%ez`, `%ed`, and `%er`; altitude, azimuth, declination, right-ascension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### ~
 
+### v0.16.6 (2025-04-14)
+* adds option for "solar midnight" (#835).
+* adds world places: ~100 places; US state capitols, major US cities, and others.
+* increases maximum "auto-dismiss after" notification value from 5 minutes to 12 hours (#726).
+* improves UI when configuring time offsets for custom events, alarm, and bedtime settings.
+* fixes bug where "sun position grid does not re-align when DST changes" (#867).
+* enhances `%e` data patterns to work with all widget types (no longer limited to sun widgets).
+* adds data patterns: `%es`, `%eS`, `%h`, and `%H`; shadow length, and observer height.
+* adds data patterns: `%ea`, `%ez`, `%ed`, and `%er`; altitude, azimuth, declination, right-ascension.
+
 ### v0.16.5 (2025-02-14)
 * adds an option to the moon dialog, solstice dialog, and solstice widget to only show the number of days remaining (#846, #847).
 * adds "gradually increase volume (curve)" to alarm options; defaults to cubic. The volume increases gradually in the beginning, rapidly increasing toward the end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ### ~
 
-### v0.16.6 (2025-04-14)
+### v0.16.6 (2025-04-16)
 * adds option for "solar midnight" (#835).
-* adds world places: ~100 places; US state capitols, major US cities, and others.
+* adds world places: ~110 places; North American capitols, major cities, and others.
 * adds an indicator to sun dialog when the displayed time is adjusted by DST.
 * fixes bug where "sun position grid does not re-align when DST changes" (#867).
 * fixes bug where "sun position graph labels are always displayed using 12h time".

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 119
-        versionName "0.16.5"
+        versionCode 120
+        versionName "0.16.6"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/120.txt
+++ b/fastlane/metadata/android/en-US/changelogs/120.txt
@@ -1,5 +1,5 @@
 - adds option for "solar midnight".
-- adds ~100 world places; US state capitols, and major US cities.
+- adds ~110 world places; North American capitols, major cities, and others.
 - adds an indicator to sun dialog when the displayed time is adjusted by DST.
 - fixes bug where "sun position grid does not re-align when DST changes" (#867).
 - fixes bug where "sun position graph labels are always displayed using 12h time".

--- a/fastlane/metadata/android/en-US/changelogs/120.txt
+++ b/fastlane/metadata/android/en-US/changelogs/120.txt
@@ -1,0 +1,4 @@
+- adds option for "solar midnight".
+- adds ~100 world places; US state capitols, and major US cities.
+- improves UI when configuring time offsets for custom events, alarm, and bedtime settings.
+- fixes bug where "sun position grid does not re-align when DST changes" (#867).

--- a/fastlane/metadata/android/en-US/changelogs/120.txt
+++ b/fastlane/metadata/android/en-US/changelogs/120.txt
@@ -1,4 +1,6 @@
 - adds option for "solar midnight".
 - adds ~100 world places; US state capitols, and major US cities.
-- improves UI when configuring time offsets for custom events, alarm, and bedtime settings.
+- adds an indicator to sun dialog when the displayed time is adjusted by DST.
 - fixes bug where "sun position grid does not re-align when DST changes" (#867).
+- fixes bug where "sun position graph labels are always displayed using 12h time".
+- improves UI when configuring time offsets for custom events, alarm, and bedtime settings.


### PR DESCRIPTION
* adds option for "solar midnight" (closes #835).
* adds world places: ~110 places; North American capitols, major US cities, and others.
* increases maximum "auto-dismiss after" notification value from 5 minutes to 12 hours (#726).
* improves UI when configuring time offsets for custom events, alarm, and bedtime settings.
* fixes bug where "sun position grid does not re-align when DST changes" (closes #867).
* enhances `%e` data patterns to work with all widget types (no longer limited to sun widgets).
* adds data patterns: `%es`, `%eS`, `%h`, and `%H`; shadow length, and observer height.
* adds data patterns: `%ea`, `%ez`, `%ed`, and `%er`; altitude, azimuth, declination, right-ascension.