### PR TITLE
release 0.16.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * fixes "app crash in the Sun Dialog when rotating the device".
 * fixes bug where custom event alarm times are truncated to the minute.
 * fixes bug where content provider fails to schedule custom events on past days.
+* increments `CalculatorProviderContract` version 8 -> 9; adds support for custom events to the `sun` query (projections may include custom event ids).
+* increments `AlarmEventContract` version 1 -> 2; eventInfo can now be queried by type with selectionArgs.
 * updates translation to Italian (it) (#893 by McCio).
 
 ### v0.16.9 (2025-07-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### ~
 
+### v0.16.10 (2025-09-01)
+* adds "Boot Completed (Delay)" to alarm settings; adds intentional delay when rescheduling alarms after reboot.
+* fixes "app crash after phone restart" (#894).
+* fixes "app crash in the Sun Dialog when rotating the device".
+* fixes bug where custom event alarm times are truncated to the minute.
+* fixes bug where content provider fails to schedule custom events on past days.
+* updates translation to Italian (it) (#893 by McCio).
+
 ### v0.16.9 (2025-07-28)
 * improves reliability of location updates (#884); adds "fused" location provider (api31+).
 * fixes bug where "data patterns display nothing at higher latitudes" (#874).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### ~
 
-### v0.16.10 (2025-09-01)
-* adds "Boot Completed (Delay)" to alarm settings; adds intentional delay when rescheduling alarms after reboot.
+### v0.16.10 (2025-09-03)
+* adds a crash report notification that displays the stacktrace when the application crashes.
+* adds "Boot Completed (Delay)" to alarm settings; an intentional delay when rescheduling alarms after reboot.
 * fixes "app crash after phone restart" (#894).
 * fixes "app crash in the Sun Dialog when rotating the device".
 * fixes bug where custom event alarm times are truncated to the minute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ### ~
 
-### v0.16.10 (2025-09-03)
+### v0.16.10 (2025-09-05)
 * adds a crash report notification that displays the stacktrace when the application crashes.
 * adds "Boot Completed (Delay)" to alarm settings; an intentional delay when rescheduling alarms after reboot.
+* adds "show cross-quarter days" option to the solstice widget.
 * fixes "app crash after phone restart" (#894).
 * fixes "app crash in the Sun Dialog when rotating the device".
+* fixes missing "reconfigure widget" action (api28+); pressing and holding the widget reveals the settings button.
 * fixes bug where custom event alarm times are truncated to the minute.
 * fixes bug where content provider fails to schedule custom events on past days.
 * increments `CalculatorProviderContract` version 8 -> 9; adds support for custom events to the `sun` query (projections may include custom event ids).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 123
-        versionName "0.16.9"
+        versionCode 124
+        versionName "0.16.10"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/124.txt
+++ b/fastlane/metadata/android/en-US/changelogs/124.txt
@@ -1,1 +1,2 @@
+- adds crash report notification.
 - updates translation to Italian.

--- a/fastlane/metadata/android/en-US/changelogs/124.txt
+++ b/fastlane/metadata/android/en-US/changelogs/124.txt
@@ -1,0 +1,1 @@
+- updates translation to Italian.


### PR DESCRIPTION
* adds a crash report notification that displays the stacktrace when the application crashes.
* adds "Boot Completed (Delay)" to alarm settings; adds intentional delay when rescheduling alarms after reboot.
* fixes "app crash after phone restart" (closes #894).
* fixes "app crash in the Sun Dialog when rotating the device".
* fixes bug where custom event alarm times are truncated to the minute.
* fixes bug where content provider fails to schedule custom events on past days.
* increments `CalculatorProviderContract` version 8 -> 9; adds support for custom events to the `sun` query (projections may include custom event ids).
* increments `AlarmEventContract` version 1 -> 2; eventInfo can now be queried by type with selectionArgs.
* updates translation to Italian (it) (#893 by McCio). #675 

