### PR TITLE
release 0.16.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.16.14 (2026-03-04)
+### v0.16.14 (2026-03-14)
 * fixes missing Chinese translations (#921) (missing since v0.16.12).
 * fixes missing region-specific default values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### ~
 
 ### v0.16.14 (2026-03-04)
-* fixes lost/missing Chinese translations (#921) (missing since v0.16.12).
+* fixes missing Chinese translations (#921) (missing since v0.16.12).
+* fixes missing region-specific default values.
 
 ### v0.16.13 (2026-02-17)
 * fixes bug where apparent solar time alarms are scheduled incorrectly (#911).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### ~
 
+### v0.16.14 (2026-03-04)
+* fixes lost/missing Chinese translations (#921) (missing since v0.16.12).
+
 ### v0.16.13 (2026-02-17)
 * fixes bug where apparent solar time alarms are scheduled incorrectly (#911).
 * fixes missing `contentDescriptions` on event icons (accessibility) (#915).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 127
-        versionName "0.16.13"
+        versionCode 128
+        versionName "0.16.14"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/128.txt
+++ b/fastlane/metadata/android/en-US/changelogs/128.txt
@@ -1,0 +1,1 @@
+- fixes lost/missing Chinese translations (#921).

--- a/fastlane/metadata/android/en-US/changelogs/128.txt
+++ b/fastlane/metadata/android/en-US/changelogs/128.txt
@@ -1,1 +1,1 @@
-- fixes lost/missing Chinese translations (#921).
+- fixes missing Chinese translations (#921).


### PR DESCRIPTION
* fixes missing Chinese translations (closes #921) (missing since v0.16.12).
* fixes missing region-specific default values.