### PR TITLE
release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.17.0 (2026-04-08)
+### v0.17.0 (2026-04-11)
 * adds `Material You` app themes (api31+) (#635).
 * adds `fancy digital clock` widgets.
 * adds `widget preview` (and `share` action) to the widget configuration activity (#6).
@@ -21,6 +21,7 @@
 * adds option to hide the location coordinates in the action bar.
 * adds option `label (alternate)` that displays alternate labels "dawn" and "dusk" in the main table.
 * adds `snooze` and `snooze limit` chips to the alarm edit dialog that allows setting these values per alarm.
+* fixes bug where alarm fade-in continues running after sound has stopped; fixes bug where alarm MediaPlayer resources aren't released.
 * adds permission `android.permission.SCHEDULE_EXACT_ALARM` (needed for alarm functionality) [permission].
 * adds permission `android.permission.POST_NOTIFICATIONS` (needed for alarm functionality) [permission].
 * adds permission `suntimes.permission.ADDON` (an experimental alternate to `suntimes.permission.READ_CALCULATOR`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ### ~
 
-### DEVELOP
-
-* adds "Material You" app themes (api31+) (#635).
-* adds "fancy" digital clock widgets.
+### v0.17.0 (2026-04-08)
+* adds `Material You` app themes (api31+) (#635).
+* adds `fancy digital clock` widgets.
 * adds `widget preview` (and `share` action) to the widget configuration activity (#6).
 * adds custom events; `shadow factor`, `day/night percent`, `moon elevation`, and `moon illumination` (#729, #900).
 * adds world map projections; Mercator, Mercator equal-area, and Van der Grinten world maps (and widgets).
@@ -13,7 +12,7 @@
 * adds `seek`, `seek dawn`, `seek dusk`, and `seek noon` menus to the sun dialog; seek to twilight or custom events.
 * adds `seek altitude` and `seek shadow length` popups to the sun dialog; seek/manage custom events.
 * adds `10min`, `15min`, and `7d` step sizes to the sun dialog, and `7d` step size to the world map dialog.
-* adds `solar noon` and sun `symbol` options to the sun dialog; "circle", "cross", "dot", or "line".
+* adds `solar noon` and sun `symbol` options to the sun dialog; `circle`, `cross`, `dot`, or `line`.
 * adds `sort places` action to the places activity; sort by label (ascending, descending), or nearest (to app location).
 * improves the `search places` action; adds descriptive tags/icons to the default world places.
 * enhances the add places dialog; adds `gps menu`, `gps status` views, `reload agps`, and `average location` actions (#884).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,13 @@
 
 ## Donations
 
-Does this app provide value? Please consider a monetary contribution if your disposable income allows it. Putting a price on the binary is a great way to show support for software you care about.
+Does this app provide value? Suntimes is available gratis, but if it has proven its value, please pay as you feel.
 
-<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=NZJ5FJBCKY6K2"><img src="/SuntimesWidget/assets/images/PP_logo_h_150x38.png" alt="paypal" /></a>
+* <a href="https://liberapay.com/forrestguice">Liberapay</a>
+* <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=NZJ5FJBCKY6K2"><img src="/SuntimesWidget/assets/images/PP_logo_h_150x38.png" alt="paypal" /></a>
 
 ## Bug Reports and Feature Requests
-Use the issue tracker to submit a bug report or a feature request.
+Use the issue tracker to submit a bug report or feature request.
 
 When reporting a bug **please be detailed as possible**. What did you expect the app to do, what did you actually observe? Include the app version number in your report. Other useful information includes the Android OS version (and sometimes your specific device model).
 

--- a/README.md
+++ b/README.md
@@ -138,13 +138,16 @@ The app benefits from the following permissions...
 |---|---|---|
 |ACCESS_COARSE_LOCATION|To get current location.|v0.1.0|
 |ACCESS_FINE_LOCATION|To get current location (GPS).|v0.1.0|
+|ACCESS_LOCATION_EXTRA_COMMANDS|To reload agps data.|v0.17.0|
 |ACCESS_NOTIFICATION_POLICY|To enable do-not-disturb at bedtime.|v0.16.0|
 |BOOT_COMPLETED|To restore active alarms when the device boots.|v0.11.0|
 |FOREGROUND_SERVICE|To display alarms and notifications.|v0.16.0|
 |POWER_OFF_ALARM|To wake the device from the power off state.|v0.14.0|
+|POST_NOTIFICATIONS|To display alarms and notifications.|v0.17.0|
 |READ_EXTERNAL_STORAGE|To play alarm sounds located on the SD card.|v0.11.5, v0.13.8 (api&le;18)|
 |REQUEST_IGNORE_BATTERY_OPTIMIZATIONS|To help ensure reliable delivery of alarms.|v0.14.11|
 |SET_ALARM|To interact with the system AlarmClock app.|v0.1.0|
+|SCHEDULE_EXACT_ALARM|To display alarms and notifications.|v0.17.0|
 |USE_FULL_SCREEN_INTENT|To display alarms over the lock screen.|v0.16.0|
 |WRITE_EXTERNAL_STORAGE|To export data (places, themes, etc.) to file.|v0.2.2 (api&le;18)|
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,8 +78,8 @@ android
             missingDimensionStrategy 'api', 'api28'
         }
 
-        versionCode 129
-        versionName "0.16.15"
+        versionCode 130
+        versionName "0.17.0"
 
         manifestPlaceholders = [suntimesAuthorityRoot:"suntimes",
                                 suntimesAuthorityRoot0:"suntimeswidget",

--- a/fastlane/metadata/android/en-US/changelogs/130.txt
+++ b/fastlane/metadata/android/en-US/changelogs/130.txt
@@ -1,0 +1,9 @@
+- adds "Material You" app themes.
+- adds "fancy digital clock" widgets.
+- adds custom events ("shadow factor", "day percent", "moon elevation", and "moon illumination").
+- adds world map projections (Mercator, Mercator equal-area, and Van der Grinten).
+- improves widget configuration (adds "widget preview").
+- improves navigation in sun, moon, and world map dialogs (seek date/time).
+- improves searching places (adds descriptive tags and "sort places" action).
+- enhances the "add places" dialog ("gnss status" and other gps related improvements).
+- updates targetSdk to Android 11 (api30), and migrates app to AndroidX.


### PR DESCRIPTION
* adds `Material You` app themes (api31+) (closes #635).
* adds `fancy digital clock` widgets.
* adds `widget preview` (and `share` action) to the widget configuration activity (closes #6).
* adds custom events; `shadow factor`, `day/night percent`, `moon elevation`, and `moon illumination` (closes #729, closes #900).
* adds world map projections; Mercator, Mercator equal-area, and Van der Grinten world maps (and widgets).
* adds `map location` picker to the location dialog; choose coordinates from the world map.
* adds `seek time/date` action to the sun, moon, and world map dialogs (closes #863).
* adds `seek bar` to the sun dialog; tapping or dragging the lightmap or graph jumps to that time (closes #826).
* adds `seek`, `seek dawn`, `seek dusk`, and `seek noon` menus to the sun dialog; seek to twilight or custom events.
* adds `seek altitude` and `seek shadow length` popups to the sun dialog; seek/manage custom events.
* adds `10min`, `15min`, and `7d` step sizes to the sun dialog, and `7d` step size to the world map dialog.
* adds `solar noon` and sun `symbol` options to the sun dialog; `circle`, `cross`, `dot`, or `line`.
* adds `sort places` action to the places activity; sort by label (ascending, descending), or nearest (to app location).
* improves the `search places` action; adds descriptive tags/icons to the default world places (closes #785).
* enhances the add places dialog; adds `gps menu`, `gps status` views, `reload agps`, and `average location` actions (#884).
* adds permission `android.permission.ACCESS_LOCATION_EXTRA_COMMANDS`; required to reload agps data [PERMISSION].
* adds `last update` location debug information to place settings; time of last update, location provider, accuracy, time elapsed, and number of satellites (closes #884).
* adds option to hide the location coordinates in the action bar.
* adds option `label (alternate)` that displays alternate labels "dawn" and "dusk" in the main table.
* adds `snooze` and `snooze limit` chips to the alarm edit dialog that allows setting these values per alarm.
* fixes bug where alarm fade-in continues running after sound has stopped; fixes bug where alarm MediaPlayer resources aren't released.
* adds permission `android.permission.SCHEDULE_EXACT_ALARM` (needed for alarm functionality) [permission].
* adds permission `android.permission.POST_NOTIFICATIONS` (needed for alarm functionality) [permission].
* adds permission `suntimes.permission.ADDON` (an experimental alternate to `suntimes.permission.READ_CALCULATOR`).
* refactor; decouples core data classes from the Android api (#388); moved into `calculator` and `util` Java libraries.
* refactor; decouples UI classes from the Android Support Library; introduces Suntimes `support` library.
* build; updates targetSdkVersion (28 -> 30) to Android 11, migrates the app to AndroidX, and replaces use of deprecated API (api30) (closes #908).
* build; adds `production` and `nightly` build flavors (#892).
* build; adds `legacy` build flavor; assign `android.targetVersion = 28` and `android.useAndroidX = false` in settings.gradle to build against the older Android Support Library.