### PR TITLE
release 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### ~
 
+### v0.17.2 (2026-05-18)
+* fixes misc `Material You` style issues (alert-dialog, action-mode, and status-bar colors).
+* fixes bug where "dialog icons are unreadable when using light themes".
+* fixes "app crash when dialog is dismissed before fully shown".
+* enhances alarm offset picker to allow finer control (no longer limited to 5m intervals).
+* enhances alarm edit UI; hides chips when options aren't supported; show simplified dialogs when options have limited support.
+* build: adds `suntimes.localization.plugin`; adds gradle tasks (`processTranslations`, `updateTranslations`).
+* updates translation to French (fr) (#944 by chfo-bidouille).
+
 ### v0.17.1 (2026-04-22)
 * fixes broken moon widgets ("problem loading widget") (#931).
 * fixes app crash when dragging world map timeline (#935).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ### ~
 
-### v0.17.2 (2026-05-18)
+### v0.17.2 (2026-05-23)
 * fixes misc `Material You` style issues (alert-dialog, action-mode, and status-bar colors).
 * fixes bug where "dialog icons are unreadable when using light themes".
 * fixes "app crash when dialog is dismissed before fully shown".
 * enhances alarm offset picker to allow finer control (no longer limited to 5m intervals).
 * enhances alarm edit UI; hides chips when options aren't supported; show simplified dialogs when options have limited support.
 * build: adds `suntimes.localization.plugin`; adds gradle tasks (`processTranslations`, `updateTranslations`).
-* updates translation to French (fr) (#944 by chfo-bidouille).
+* updates translation to French (fr) (#944, #948, #951 by chfo-bidouille).
+* updates translation to Brazilian Portuguese (pt-br) (#950 by naoliv).
 
 ### v0.17.1 (2026-04-22)
 * fixes broken moon widgets ("problem loading widget") (#931).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### ~
 
 ### v0.17.2 (2026-05-23)
+* fixes broken alarm list widgets (#949).
 * fixes misc `Material You` style issues (alert-dialog, action-mode, and status-bar colors).
 * fixes bug where "dialog icons are unreadable when using light themes".
 * fixes "app crash when dialog is dismissed before fully shown".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 ### ~
 
 ### v0.17.2 (2026-05-23)
+* adds "material widget" themes: `Dark/Light/System (MD2)`, and `Dark/Light/System (Material)` themes (#934); renames legacy themes to `Dark/Light (Holo)`.
+* adds typeface options to the clock widget; color, font-family, bold, italic, outline, and cutout options.
 * fixes broken alarm list widgets (#949).
 * fixes misc `Material You` style issues (alert-dialog, action-mode, and status-bar colors).
-* fixes bug where "dialog icons are unreadable when using light themes".
-* fixes "app crash when dialog is dismissed before fully shown".
+* fixes bug where "alert dialog icons are unreadable when using light themes".
+* fixes bug "app crash when dialog is dismissed before fully shown".
+* fixes bug where widget previews are broken when using the layout selector.
+* fixes bug where color chooser changes color after the dialog is canceled.
+* fixes bug where transparent widgets are missing their pressed appearance.
 * enhances alarm offset picker to allow finer control (no longer limited to 5m intervals).
 * enhances alarm edit UI; hides chips when options aren't supported; show simplified dialogs when options have limited support.
+* changes default widget theme to `Dark (Material)`; changes default clock widget to `clock2`.
+* refactors sun widget layouts; tweaks widget scaling to accommodate material widgets.
 * build: adds `suntimes.localization.plugin`; adds gradle tasks (`processTranslations`, `updateTranslations`).
 * updates translation to French (fr) (#944, #948, #951 by chfo-bidouille).
 * updates translation to Brazilian Portuguese (pt-br) (#950 by naoliv).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android
             missingDimensionStrategy 'api', 'api28'
         }
 
-        versionCode 131
-        versionName "0.17.1"
+        versionCode 132
+        versionName "0.17.2"
 
         manifestPlaceholders = [suntimesAuthorityRoot:"suntimes",
                                 suntimesAuthorityRoot0:"suntimeswidget",

--- a/fastlane/metadata/android/en-US/changelogs/132.txt
+++ b/fastlane/metadata/android/en-US/changelogs/132.txt
@@ -1,0 +1,5 @@
+Attention: v0.17.0+ breaks older widget installations (#932).
+When updating from previous versions your home screen widgets may be removed and will need to be re-added.
+
+- fixes misc `Material You` style issues.
+- updates translation to French.

--- a/fastlane/metadata/android/en-US/changelogs/132.txt
+++ b/fastlane/metadata/android/en-US/changelogs/132.txt
@@ -3,3 +3,4 @@ When updating from previous versions your home screen widgets may be removed and
 
 - fixes misc `Material You` style issues.
 - updates translation to French.
+- updates translation to Portuguese.

--- a/fastlane/metadata/android/en-US/changelogs/132.txt
+++ b/fastlane/metadata/android/en-US/changelogs/132.txt
@@ -1,6 +1,7 @@
 Attention: v0.17.0+ breaks older widget installations (#932).
 When updating from previous versions your home screen widgets may be removed and will need to be re-added.
 
+- fixes broken alarm list widgets (#949).
 - fixes misc `Material You` style issues.
 - updates translation to French.
 - updates translation to Portuguese.

--- a/fastlane/metadata/android/en-US/changelogs/132.txt
+++ b/fastlane/metadata/android/en-US/changelogs/132.txt
@@ -1,7 +1,9 @@
 Attention: v0.17.0+ breaks older widget installations (#932).
 When updating from previous versions your home screen widgets may be removed and will need to be re-added.
 
+- adds "Material" widget themes.
+- adds color and typeface options to the clock widget.
 - fixes broken alarm list widgets (#949).
-- fixes misc `Material You` style issues.
+- fixes miscellaneous `Material You` color issues.
 - updates translation to French.
 - updates translation to Portuguese.


### PR DESCRIPTION
* adds "material widget" themes: `Dark/Light/System (MD2)`, and `Dark/Light/System (Material)` themes (closes #934); renames legacy themes to `Dark/Light (Holo)`.
* adds typeface options to the clock widget; color, font-family, bold, italic, outline, and cutout options.
* fixes broken alarm list widgets (closes #949).
* fixes misc `Material You` style issues (alert-dialog, action-mode, and status-bar colors).
* fixes bug where "alert dialog icons are unreadable when using light themes".
* fixes bug "app crash when dialog is dismissed before fully shown".
* fixes bug where widget previews are broken when using the layout selector.
* fixes bug where color chooser changes color after the dialog is canceled.
* fixes bug where transparent widgets are missing their pressed appearance.
* enhances alarm offset picker to allow finer control (no longer limited to 5m intervals).
* enhances alarm edit UI; hides chips when options aren't supported; show simplified dialogs when options have limited support.
* changes default widget theme to `Dark (Material)`; changes default clock widget to `clock2`.
* refactors sun widget layouts; tweaks widget scaling to accommodate material widgets.
* build: adds `suntimes.localization.plugin`; adds gradle tasks (`processTranslations`, `updateTranslations`).
* updates translation to French (fr) (#944, #948, #951 by chfo-bidouille).
* updates translation to Brazilian Portuguese (pt-br) (#950 by naoliv).