### PR TITLE
release 0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### ~
 
 ### v0.17.4 (2026-07-26)
+* fixes app crash when using `cc` calculator with longitudes over +-165 degrees (#966).
+* fixes app crash when changing widget padding (#963).
 * fixes bug where "latest sunset time is slightly off" (#960).
 * fixes bug where "sunlight dialog does not honor the `show seconds` option".
 * fixes bug where "sunlight dialog `share` does not honor the `time zone` option".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * fixes bug where "latest sunset time is slightly off" (#960).
 * fixes bug where "sunlight dialog does not honor the `show seconds` option".
 * fixes bug where "sunlight dialog `share` does not honor the `time zone` option".
+* build: updated to support jdk21 (minimum required is now jdk17+); updates gradle `7.4.0 -> 8.5.2`; updates agp `7.5 -> 8.7`.
 * updates translation to Italian (it) (#964 by McCio).
 * updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#962 by James Liu).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.17.4 (2026-06-26)
+* fixes bug where "latest sunset time is slightly off" (#960).
+* fixes bug where "sunlight dialog does not honor the `show seconds` option".
+* fixes bug where "sunlight dialog `share` does not honor the `time zone` option".
+* updates translation to Italian (it) (#964 by McCio).
+* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#962 by James Liu).
+
 ### v0.17.3 (2026-06-22)
 * extends the "set background" world map action; additional map backgrounds are now available as an addon (https://github.com/forrestguice/SuntimesMapPack).
 * fixes inconsistent Mercator and Van der Grinten projection extents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.17.4 (2026-06-26)
+### v0.17.4 (2026-07-26)
 * fixes bug where "latest sunset time is slightly off" (#960).
 * fixes bug where "sunlight dialog does not honor the `show seconds` option".
 * fixes bug where "sunlight dialog `share` does not honor the `time zone` option".

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android
             missingDimensionStrategy 'api', 'api28'
         }
 
-        versionCode 133
-        versionName "0.17.3"
+        versionCode 134
+        versionName "0.17.4"
 
         manifestPlaceholders = [suntimesAuthorityRoot:"suntimes",
                                 suntimesAuthorityRoot0:"suntimeswidget",

--- a/fastlane/metadata/android/en-US/changelogs/134.txt
+++ b/fastlane/metadata/android/en-US/changelogs/134.txt
@@ -1,0 +1,3 @@
+- fixes bug where "latest sunset time is slightly off" (#960).
+- updates translation to Italian.
+- updates translations to Simplified Chinese and Traditional Chinese.

--- a/fastlane/metadata/android/en-US/changelogs/134.txt
+++ b/fastlane/metadata/android/en-US/changelogs/134.txt
@@ -1,3 +1,5 @@
+- fixes app crash when using `cc` calculator with longitudes over +-165 degrees (#966).
+- fixes app crash when changing widget padding (#963).
 - fixes bug where "latest sunset time is slightly off" (#960).
 - updates translation to Italian.
 - updates translations to Simplified Chinese and Traditional Chinese.


### PR DESCRIPTION
* fixes app crash when using `cc` calculator with longitudes over +-165 degrees (closes #966).
* fixes app crash when changing widget padding (closes #963).
* fixes bug where "latest sunset time is slightly off" (closes #960).
* fixes bug where "sunlight dialog does not honor the `show seconds` option".
* fixes bug where "sunlight dialog `share` does not honor the `time zone` option".
* build: updated to support jdk21 (minimum required is now jdk17+); updates gradle `7.4.0 -> 8.5.2`; updates agp `7.5 -> 8.7` (#968).
* updates translation to Italian (it) (#964 by McCio).
* updates translations to Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) (#962 by James Liu).