### PR TITLE
release 0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### ~
 
+### v0.17.5 (2026-08-26)
+* fixes bug where "date widgets display wrong month names" (#970).
+* fixes bug where "object height popup shows the wrong units label" (#969).
+* fixes app crash when using location picker from widget configuration activity.
+* fixes screen flash when showing map picker dialog over the location dialog.
+* adds world places; ~59 places; US national parks.
+
 ### v0.17.4 (2026-07-26)
 * fixes app crash when using `cc` calculator with longitudes over +-165 degrees (#966).
 * fixes app crash when changing widget padding (#963).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ### ~
 
-### v0.17.5 (2026-08-26)
+### v0.17.5 (2026-08-30)
 * fixes bug where "date widgets display wrong month names" (#970).
 * fixes bug where "object height popup shows the wrong units label" (#969).
 * fixes app crash when using location picker from widget configuration activity.
 * fixes screen flash when showing map picker dialog over the location dialog.
+* adds world places; ~34 places (Africa), ~75 places (Asia), ~3 places (Europe).
 * adds world places; ~59 places; US national parks.
+* adds translation to Slovak (sk) (contributed by padi-sk) (#975).
 
 ### v0.17.4 (2026-07-26)
 * fixes app crash when using `cc` calculator with longitudes over +-165 degrees (#966).

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Dutch translation by <u><a href=https://github.com/joppla>Joppla</a></u>.<br />
 Czech translation by <u><a href=https://github.com/utaxiu>utaxiu</a></u>.<br />
 Simplified Chinese translation by <u><a href=https://github.com/jamesliu96>James Liu</a></u>, and <u><a href=https://github.com/sr093906>sr093906</a></u>.<br />
 Arabic translation by <u><a href=https://github.com/mstfelg>Alelg</a></u>, and <u><a href=https://github.com/islam2hamy>islam2hamy</a></u>.<br />
-
+Slovak translation by <u><a href=https://github.com/padi-sk>padi-sk</a></u>.<br />
 
 [Contributions to the project](CONTRIBUTING.md) are welcome.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android
             missingDimensionStrategy 'api', 'api28'
         }
 
-        versionCode 134
-        versionName "0.17.4"
+        versionCode 135
+        versionName "0.17.5"
 
         manifestPlaceholders = [suntimesAuthorityRoot:"suntimes",
                                 suntimesAuthorityRoot0:"suntimeswidget",

--- a/fastlane/metadata/android/en-US/changelogs/135.txt
+++ b/fastlane/metadata/android/en-US/changelogs/135.txt
@@ -1,0 +1,4 @@
+- fixes bug where "date widgets display wrong month names" (#970).
+- fixes bug where "object height popup shows the wrong units label" (#969).
+- fixes app crash when using location picker from widget configuration activity.
+- adds world places; ~59 places; US national parks.

--- a/fastlane/metadata/android/en-US/changelogs/135.txt
+++ b/fastlane/metadata/android/en-US/changelogs/135.txt
@@ -1,4 +1,5 @@
 - fixes bug where "date widgets display wrong month names" (#970).
 - fixes bug where "object height popup shows the wrong units label" (#969).
 - fixes app crash when using location picker from widget configuration activity.
-- adds world places; ~59 places; US national parks.
+- adds world places; 172 places (Africa, Asia, North America).
+- adds translation to Slovak.


### PR DESCRIPTION
* fixes bug where "date widgets display wrong month names" (closes #970).
* fixes bug where "object height popup shows the wrong units label" (closes #969).
* fixes app crash when using location picker from widget configuration activity.
* fixes screen flash when showing map picker dialog over the location dialog.
* adds world places; ~34 places (Africa), ~75 places (Asia), ~3 places (Europe).
* adds world places; ~59 places; US national parks.
* adds translation to Slovak (sk) (contributed by padi-sk) (#975).